### PR TITLE
fix: [FOR-415] Avoid creation of duplicate responses

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/form/core/constants/Field.java
@@ -2,16 +2,19 @@ package fr.openent.form.core.constants;
 
 public class Field {
     // SQL columns
-    public static final String ID = "id";
-    public static final String FORM_ID = "form_id";
-    public static final String QUESTION_ID = "question_id";
+    public static final String ANSWER = "answer";
+    public static final String CHOICE_ID = "choice_id";
     public static final String DISTRIBUTION_ID = "distribution_id";
+    public static final String FORM_ID = "form_id";
+    public static final String ID = "id";
+    public static final String QUESTION_ID = "question_id";
+    public static final String RESPONDER_ID = "responder_id";
     public static final String STATUS = "status";
 
     // Request params
     public static final String PARAM_FORM_ID = "formId";
-    public static final String PARAM_QUESTION_ID = "questionId";
     public static final String PARAM_NB_LINES = "nbLines";
+    public static final String PARAM_QUESTION_ID = "questionId";
 
 
     private Field() {

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseController.java
@@ -21,6 +21,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.http.filter.ResourceFilter;
+import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
 
 import java.text.ParseException;
@@ -28,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 
 import static fr.openent.form.core.constants.DistributionStatus.FINISHED;
+import static fr.openent.form.core.constants.Field.*;
 import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
 import static fr.openent.form.core.constants.ShareRights.RESPONDER_RESOURCE_RIGHT;
 import static fr.openent.form.helpers.RenderHelper.*;
@@ -218,7 +220,7 @@ public class ResponseController extends ControllerHelper {
                                 badRequest(request, message);
                                 return;
                             }
-                            responseService.create(response, user, questionId, defaultResponseHandler(request));
+                            createResponse(request, response, user, questionId);
                         });
                     }
                     else {
@@ -230,10 +232,47 @@ public class ResponseController extends ControllerHelper {
                             try { timeFormatter.parse(response.getString("answer")); }
                             catch (ParseException e) { e.printStackTrace(); }
                         }
-                        responseService.create(response, user, questionId, defaultResponseHandler(request));
+                        createResponse(request, response, user, questionId);
                     }
                 });
             });
+        });
+    }
+
+    private void createResponse(HttpServerRequest request, JsonObject response, UserInfos user, String questionId) {
+        Integer distributionId = response.getInteger(DISTRIBUTION_ID, null);
+        Integer choiceId = response.getInteger(CHOICE_ID, null);
+        String answer = response.getString(ANSWER, null);
+
+        responseService.listMineByDistribution(questionId, distributionId.toString(), user, listEvt -> {
+            if (listEvt.isLeft()) {
+                log.error("[Formulaire@createResponse] Fail to list responses : " + listEvt.left().getValue());
+                renderInternalError(request, listEvt);
+                return;
+            }
+
+            JsonArray responses = listEvt.right().getValue();
+            boolean found = false;
+            int i = 0;
+            while (!found && i < responses.size()) {
+                JsonObject r = responses.getJsonObject(i);
+                boolean checkQuestionId = r.getInteger(QUESTION_ID).toString().equals(questionId);
+                boolean checkResponderId = r.getString(RESPONDER_ID).equals(user.getUserId());
+                boolean checkDistributionId = r.getInteger(DISTRIBUTION_ID).equals(distributionId);
+                boolean checkAnswerId = r.getString(ANSWER).equals(answer);
+                boolean checkChoiceId = r.getInteger(CHOICE_ID) == choiceId;
+                found = checkQuestionId && checkResponderId && checkDistributionId && checkAnswerId && checkChoiceId;
+                i++;
+            }
+
+            if (found) {
+                String message = "[Formulaire@createResponse] An identical response already exists " + responses.getJsonObject(i-1);
+                log.error(message);
+                conflict(request, message);
+                return;
+            }
+
+            responseService.create(response, user, questionId, defaultResponseHandler(request));
         });
     }
 


### PR DESCRIPTION
## Describe your changes
For an unknown reason, duplicate responses appear in the database.
The goal here is to prevent the creation of the response if database already contains identical ones.

## Checklist tests

## Issue ticket number and link
FOR-415 : https://jira.support-ent.fr/browse/FOR-415

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)