### PR TITLE
fix(css): [FOR-417] Disable switches on edit questions when there are already responses

### DIFF
--- a/formulaire/src/main/resources/public/sass/global/_formulaire.scss
+++ b/formulaire/src/main/resources/public/sass/global/_formulaire.scss
@@ -156,6 +156,14 @@ body.formulaire section.main {
     align-items: baseline;
   }
 
+  switch.switchoff span {
+    background: $formulaire-grey-light !important;
+
+    &:before {
+      background: $formulaire-grey !important;
+    }
+  }
+
 
   // Forms-list
 

--- a/formulaire/src/main/resources/public/sass/global/components/_edit-form.scss
+++ b/formulaire/src/main/resources/public/sass/global/components/_edit-form.scss
@@ -108,6 +108,7 @@
           .question-bottom, .section-bottom {
             display: flex;
             justify-content: flex-end;
+            margin-top: 1%;
 
             .mandatory, .conditional {
               margin-right: 2%;

--- a/formulaire/src/main/resources/public/ts/directives/question/question-item.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-item.ts
@@ -48,10 +48,14 @@ export const questionItem: Directive = ng.directive('questionItem', () => {
                         <!-- Interaction buttons-->
                         <div class="question-bottom" ng-if="vm.question.selected">
                             <div class="mandatory" ng-if="vm.question.question_type != vm.Types.FREETEXT" title="[[vm.getTitle('mandatory.explanation')]]">
-                                <switch ng-model="vm.question.mandatory" ng-change="vm.onSwitchMandatory(vm.question.mandatory)"></switch><i18n>formulaire.mandatory</i18n>
+                                <switch ng-model="vm.question.mandatory" ng-class="{switchoff: vm.hasFormResponses}"
+                                        ng-change="vm.onSwitchMandatory(vm.question.mandatory)"></switch>
+                                <i18n>formulaire.mandatory</i18n>
                             </div>
                             <div class="conditional" ng-if="vm.showConditionalSwitch()">
-                                <switch ng-model="vm.question.conditional" ng-change="vm.onSwitchConditional(vm.question.conditional)"></switch><i18n>formulaire.conditional</i18n>
+                                <switch ng-model="vm.question.conditional" ng-class="{switchoff: vm.hasFormResponses}"
+                                        ng-change="vm.onSwitchConditional(vm.question.conditional)"></switch>
+                                <i18n>formulaire.conditional</i18n>
                             </div>
                             <i class="i-duplicate lg-icon spaced-right" ng-click="vm.duplicateQuestion()"
                                 ng-class="{disabled: vm.hasFormResponses}"  title="[[vm.getTitle('duplicate')]]"></i>
@@ -120,6 +124,9 @@ export const questionItem: Directive = ng.directive('questionItem', () => {
             };
 
             vm.onSwitchConditional = (isConditional: boolean) : void => {
+                if (vm.hasFormResponses) {
+                    vm.question.conditional = !isConditional;
+                }
                 vm.question.mandatory = isConditional;
                 $scope.$apply();
             };


### PR DESCRIPTION
## Describe your changes
When at least one person has responded to the form we block the posibility to use the switches on edit questions.
We also changed the design to make them look like disabled in this situation.

## Checklist tests

## Issue ticket number and link
FOR-417 : https://jira.support-ent.fr/browse/FOR-417

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)