### PR TITLE
fix(sharePanel): [FOR-426] hide public link on sharing close confirmation pop up

### DIFF
--- a/formulaire/src/main/resources/public/template/lightbox/form-sharing.html
+++ b/formulaire/src/main/resources/public/template/lightbox/form-sharing.html
@@ -1,7 +1,7 @@
 <lightbox show="vm.display.lightbox.sharing" on-close="vm.closeShareFormLightbox()">
     <share-panel app-prefix="formulaire" resources="vm.forms.selected" auto-close="true"></share-panel>
 
-    <div ng-if="vm.forms.selected[0].is_public">
+    <div ng-if="!vm.isCloseConfirmationOpen() && vm.forms.selected[0].is_public">
         <h2><i18n>formulaire.share.link.access</i18n></h2>
         <div class="public_link">
             <div class="text ellipsis">[[vm.forms.selected[0].getPublicLink()]]</div>
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-    <div class="action-buttons alone">
+    <div class="action-buttons alone" ng-if="!vm.isCloseConfirmationOpen()">
         <button class="cell cancel" ng-click="vm.closeShareFormLightbox()"><i18n>formulaire.close</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -120,6 +120,7 @@ interface ViewModel {
     getTitle(title: string) : string;
     infiniteScroll() : void;
     seeMore() : void;
+    isCloseConfirmationOpen() : boolean;
     $onDestroy() : Promise<void>;
 }
 
@@ -765,6 +766,18 @@ export const formsListController = ng.controller('FormsListController', ['$scope
     vm.seeMore = () :void =>{
         vm.limitTable += vm.tableSize;
     };
+
+    vm.isCloseConfirmationOpen = () : boolean => {
+        let elems = document.getElementsByTagName('share-panel');
+        if (elems && elems.length > 0 && elems[0].firstElementChild) {
+            let elem: ElementTraversal = elems[0].firstElementChild;
+            let sharePanelScope = angular.element(elem).scope();
+            if (sharePanelScope && sharePanelScope.display) {
+                return sharePanelScope.display.showCloseConfirmation;
+            }
+        }
+        return false;
+    }
 
     const initMail = () : void => {
         let endPath = vm.forms.selected[0].rgpd ? 'rgpd' : 'new';


### PR DESCRIPTION
## Describe your changes
Check if sharePanel close confirmation pop up is open and if it is we do not show the public link and its button.

## Checklist tests

## Issue ticket number and link
FOR-426 : https://jira.support-ent.fr/browse/FOR-426

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)