### PR TITLE
fix: [FOR-396] fix saving behaviour on edit-form page

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -698,30 +698,18 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 rePositionFormElements(vm.formElements);
                 let formElement = vm.formElements.getSelectedElement();
                 if (formElement) {
-                    if (formElement instanceof Question && !formElement.title && !formElement.statement && !formElement.mandatory && formElement.choices.all.length <= 0) {
-                        if (formElement.id) {
-                            vm.formElements.all.filter(e => e.id)[0] = await questionService.get(formElement.id);
-                        }
-                    }
-                    else if (formElement instanceof Section && !formElement.title && !formElement.description && formElement.questions.all.length <= 0) {
-                        if (formElement.id) {
-                            vm.formElements.all.filter(e => e.id)[0] = await sectionService.get(formElement.id);
-                        }
-                    }
-                    else {
-                        let test = await formElementService.save(formElement);
-                        let newId = test.id;
-                        formElement.id = newId;
+                    let savedElement = await formElementService.save(formElement);
+                    let newId: number = savedElement.id;
+                    formElement.id = newId;
 
-                        if (formElement instanceof Question) {
-                            let registeredChoices = [];
-                            formElement.choices.replaceSpace();
-                            for (let choice of formElement.choices.all) {
-                                if (choice.value && !registeredChoices.find(c => c === choice.value)) {
-                                    choice.question_id = newId;
-                                    choice.id = (await questionChoiceService.save(choice)).id;
-                                    registeredChoices.push(choice.value);
-                                }
+                    if (formElement instanceof Question) {
+                        let registeredChoiceValues: string[] = [];
+                        formElement.choices.replaceSpace();
+                        for (let choice of formElement.choices.all) {
+                            if (choice.value && !registeredChoiceValues.find(v => v === choice.value)) {
+                                choice.question_id = newId;
+                                choice.id = (await questionChoiceService.save(choice)).id;
+                                registeredChoiceValues.push(choice.value);
                             }
                         }
                     }

--- a/formulaire/src/main/resources/public/ts/directives/question/section-item.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/section-item.ts
@@ -12,6 +12,7 @@ interface IViewModel {
     getTitle(title: string): string;
     editSection(): void;
     deleteSection(): void;
+    isOtherElementSelected(): boolean;
     undoSectionChanges(): void;
     validateSection(): void;
     deleteQuestion(): void;
@@ -36,7 +37,7 @@ export const sectionItem: Directive = ng.directive('sectionItem', () => {
         template: `
             <div class="ten section-item">
                 <div class="domino" ng-class="{'sectionError': !vm.section.title || vm.verifConditional()}">
-                    <div class="section-top" ng-class="{disabled: vm.hasFormResponses || vm.section.selected}">
+                    <div class="section-top" ng-class="{'disabled & dontSave': vm.hasFormResponses || vm.section.selected}">
                         <!-- Drag and drop icon -->
                         <div class="section-top-dots grab">
                             <div class="dots" ng-if="vm.reorder || !vm.hasFormResponses">
@@ -47,16 +48,17 @@ export const sectionItem: Directive = ng.directive('sectionItem', () => {
                         <div class="section-top-container">
                             <!-- Title component -->
                             <div class="title twelve" guard-root="formTitle">
-                                <div class="dontSave flex-spaced" ng-if="!vm.section.selected">
+                                <div class="flex-spaced" ng-if="!vm.section.selected">
                                     <h4 ng-if="vm.section.title" class="ellipsis">
                                         [[vm.section.title]]
                                     </h4>
                                     <h4 ng-if="!vm.section.title" class="empty">
                                         <i18n>formulaire.section.title.empty</i18n>
                                     </h4>
-                                    <i class="i-edit md-icon" ng-click="vm.editSection()" title="[[vm.getTitle('edit')]]"></i>
+                                    <i class="i-edit md-icon dontSave" ng-click="vm.editSection()" title="[[vm.getTitle('edit')]]"
+                                        ng-if="!vm.isOtherElementSelected()"></i>
                                 </div>
-                                <div class="top-spacing-twice dontSave" ng-if="vm.section.selected">
+                                <div class="top-spacing-twice" ng-if="vm.section.selected">
                                     <input type="text" class="twelve" i18n-placeholder="formulaire.section.title.empty"
                                            ng-model="vm.section.title" ng-keydown="$event.keyCode === 13 && vm.validateSection()" input-guard>
                                 </div>
@@ -133,6 +135,12 @@ export const sectionItem: Directive = ng.directive('sectionItem', () => {
                 if (!vm.hasFormResponses) {
                     $scope.$emit(FORMULAIRE_FORM_ELEMENT_EMIT_EVENT.DELETE_ELEMENT);
                 }
+            };
+
+            vm.isOtherElementSelected = () : boolean => {
+                let hasSelectedChild: boolean = vm.section.questions.all.filter(q => q.selected).length > 0;
+                let hasSiblingChild: boolean = vm.formElements.hasSelectedElement() && vm.formElements.getSelectedElement().id != vm.section.id;
+                return hasSelectedChild || hasSiblingChild;
             };
 
             vm.undoSectionChanges = () : void => {


### PR DESCRIPTION
## Describe your changes
We change the saving behaviour of questions on edit-form page :
- we do not block saving of questions without title anymore
- we hide edit section icon when editing another element
- we improve saving and non-saving area behaviours

## Checklist tests

## Issue ticket number and link
FOR-396 : https://jira.support-ent.fr/browse/FOR-396

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)