### PR TITLE
fix(DnD): [FOR-431] remove clean residue (obsolete) on DnD question in edit-form

### DIFF
--- a/common/src/main/resources/ts/utils/formElement.ts
+++ b/common/src/main/resources/ts/utils/formElement.ts
@@ -104,27 +104,27 @@ export class FormElementUtils {
 
     // Drag and drop
 
-    static onEndDragAndDrop = async (evt: any, formElements: FormElements) : Promise<boolean> => {
-        let scopElem = angular.element(evt.item.firstElementChild.firstElementChild).scope().vm;
-        let itemId = scopElem.question ? scopElem.question.id : scopElem.section.id;
-        let newNestedSectionId = evt.to.id.split("-")[1] != "0" ? parseInt(evt.to.id.split("-")[1]) : null;
-        let oldNestedContainerId = evt.from.id.split("-")[1] != "0" ? parseInt(evt.from.id.split("-")[1]) : null;
-        let oldSection = oldNestedContainerId ? (formElements.all.filter(e => e instanceof Section && e.id === oldNestedContainerId)[0]) as Section: null;
-        let item = null;
-        if (scopElem.section) {
-            item = formElements.all.filter(q => q.id === itemId)[0] as Section;
+    static onEndDragAndDrop = async (evt: any, formElements: FormElements) : Promise<void> => {
+        let scopeElem: any = angular.element(evt.item.firstElementChild.firstElementChild).scope().vm;
+        let itemId: number = scopeElem.question ? scopeElem.question.id : scopeElem.section.id;
+        let newNestedSectionId: number = evt.to.id.split("-")[1] != "0" ? parseInt(evt.to.id.split("-")[1]) : null;
+        let oldNestedContainerId: number = evt.from.id.split("-")[1] != "0" ? parseInt(evt.from.id.split("-")[1]) : null;
+        let oldSection: Section = oldNestedContainerId ? (formElements.all.filter(e => e instanceof Section && e.id === oldNestedContainerId)[0]) as Section : null;
+        let item: any = null;
+        if (scopeElem.section) {
+            item = formElements.all.filter(e => e.id === itemId)[0] as Section;
         }
         else {
-            let oldSiblings = oldSection ? oldSection.questions : formElements;
-            item = (oldSiblings as any).all.filter(q => q.id === itemId)[0] as Question;
+            let oldSiblings: any = oldSection ? oldSection.questions : formElements;
+            item = oldSiblings.all.filter(e => e.id === itemId)[0] as Question;
         }
-        let oldIndex = evt.oldIndex;
-        let newIndex = evt.newIndex;
-        let indexes = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
-        let cleanResidue = false;
+        let oldIndex: number = evt.oldIndex;
+        let newIndex: number = evt.newIndex;
+        let indexes: any = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
 
+        // We cannot move a section into another section
         if (newNestedSectionId && item instanceof Section) {
-            return false;
+            return;
         }
 
         if (!newNestedSectionId) {
@@ -138,7 +138,6 @@ export class FormElementUtils {
                 await questionService.update(oldSection.questions.all);
                 formElements.all.push(item);
                 await formElementService.update(formElements.all);
-                cleanResidue = true;
             }
             else { // Item moved FROM vm.formElements TO vm.formElements
                 FormElementUtils.updateSiblingsPositions(formElements, true, indexes.goUp, indexes.startIndex, indexes.endIndex);
@@ -149,7 +148,7 @@ export class FormElementUtils {
             }
         }
         else {
-            let newSection = (formElements.all.filter(e => e instanceof Section && e.id === newNestedSectionId)[0]) as Section;
+            let newSection: Section = (formElements.all.filter(e => e instanceof Section && e.id === newNestedSectionId)[0]) as Section;
             if (oldSection) { // Item moved FROM oldSection TO section with id 'newNestedSectionId'
                 if (newSection.id != oldSection.id) {
                     FormElementUtils.updateSiblingsPositions(oldSection.questions, false, null, oldIndex);
@@ -179,8 +178,6 @@ export class FormElementUtils {
                 await formElementService.update(formElements.all);
             }
         }
-
-        return cleanResidue;
     };
 
     static onEndOrgaDragAndDrop = async (evt: any, formElements: FormElements) : Promise<boolean> => {
@@ -203,6 +200,7 @@ export class FormElementUtils {
         let newIndex = evt.newIndex;
         let indexes = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
 
+        // We cannot move a section into another section
         if (newNestedSectionId && item instanceof Section) {
             return true;
         }

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -638,15 +638,11 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                         document.querySelector('header').style.pointerEvents = 'none';
                     },
                     onEnd: async function (evt) {
-                        let cleanResidue = await FormElementUtils.onEndDragAndDrop(evt, vm.formElements);
+                        await FormElementUtils.onEndDragAndDrop(evt, vm.formElements);
                         document.querySelector('header').style.removeProperty('pointer-events');
                         $scope.safeApply();
 
                         await vm.$onInit();
-                        if (cleanResidue) {
-                            document.getElementById('container-0').lastElementChild.remove();
-                            $scope.safeApply();
-                        }
                     }
                 }));
             }


### PR DESCRIPTION
## Describe your changes
An old problem on form edition was the apparition of a "phantom question", a kind of question duplicated but not really existing (disapear on refresh). It was happenning when drag and drop a question from a section outside of it.
A fix was made to delete this unwanted effect.

But since a fix was made on the drag and drop this effect doesn't happen anymore and the fix is now obsolete and created another problem.

So here, we removed that obsolete fix.

## Checklist tests

## Issue ticket number and link
FOR-431 : https://jira.support-ent.fr/browse/FOR-431

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)