### PR TITLE
fix(position) : [FOR-464] fix initialisation of choices' positions

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -737,22 +737,28 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                         // Create choices
                         let registeredChoiceValues: string[] = [];
                         formElement.choices.replaceSpace();
+                        let positionCounter: number = 1;
                         for (let choice of formElement.choices.all) {
                             if (choice.value && !registeredChoiceValues.find(v => v === choice.value)) {
+                                choice.position = positionCounter;
                                 choice.question_id = newId;
                                 choice.id = (await questionChoiceService.save(choice)).id;
                                 registeredChoiceValues.push(choice.value);
+                                positionCounter++;
                             }
                         }
                         // Create children (for MATRIX questions)
+                        positionCounter = 1;
                         if (formElement.question_type === Types.MATRIX) {
                             let registeredChildrenTitles: string[] = [];
                             for (let child of formElement.children.all) {
                                 if (child.title && !registeredChildrenTitles.find((t: string) => t === child.title)) {
+                                    child.matrix_position = positionCounter;
                                     child.matrix_id = newId;
                                     child.form_id = formElement.form_id;
                                     child.id = (await questionService.save(child)).id;
                                     registeredChildrenTitles.push(child.title);
+                                    positionCounter++;
                                 }
                             }
                         }


### PR DESCRIPTION
## Describe your changes
Fix initialisation of choices' positions.
By default 3 empty choices are displayed. If you fill the second one for instance and then save your question, your choice will registered with position equal to 2 when it should be 1 because it's the only valid choice (when we have at least one valid choice we stop displaying empty default choices).

## Checklist tests

## Issue ticket number and link
FOR-464 : https://jira.support-ent.fr/browse/FOR-464

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)