### PR TITLE
fix(order): [FOR-475] force order of choices and matrix children where not defined yet

### DIFF
--- a/formulaire-public/src/main/resources/public/ts/directives/public-matrix.ts
+++ b/formulaire-public/src/main/resources/public/ts/directives/public-matrix.ts
@@ -38,7 +38,7 @@ export const publicMatrix: Directive = ng.directive('publicMatrix', () => {
                             </tr>
                         </thead>
                         <tbody>
-                            <tr ng-repeat="child in vm.question.children.all" ng-init="childIndex = $index">
+                            <tr ng-repeat="child in vm.question.children.all | orderBy:matrix_position" ng-init="childIndex = $index">
                                 <td>[[child.title]]</td>
                                 <td ng-repeat ="choice in vm.question.choices.all | orderBy:['position', 'id']">
                                     <label>

--- a/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
+++ b/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
@@ -41,7 +41,7 @@ export const publicQuestionItem: Directive = ng.directive('publicQuestionItem', 
                     <div ng-if="vm.question.question_type == vm.Types.SINGLEANSWER">
                         <select ng-model="vm.responses.all[0].choice_id" input-guard>
                             <option ng-value="">[[vm.I18n.translate('formulaire.public.options.select')]]</option>
-                            <option ng-repeat="choice in vm.question.choices.all" ng-value="choice.id">[[choice.value]]</option>
+                            <option ng-repeat="choice in vm.question.choices.all | orderBy:['position', 'id']" ng-value="choice.id">[[choice.value]]</option>
                         </select>
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.MULTIPLEANSWER">

--- a/formulaire/src/main/resources/public/ts/directives/question/recap-question-item.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/recap-question-item.ts
@@ -99,7 +99,7 @@ export const recapQuestionItem: Directive = ng.directive('recapQuestionItem', ()
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr ng-repeat="child in vm.question.children.all" ng-init="childIndex = $index">
+                                <tr ng-repeat="child in vm.question.children.all | orderBy:matrix_position" ng-init="childIndex = $index">
                                     <td>[[child.title]]</td>
                                     <td ng-repeat ="choice in vm.question.choices.all | orderBy:['position', 'id']">
                                         <label>

--- a/formulaire/src/main/resources/public/ts/directives/question/respond-matrix.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/respond-matrix.ts
@@ -46,7 +46,7 @@ export const respondMatrix: Directive = ng.directive('respondMatrix', () => {
                             </tr>
                         </thead>
                         <tbody>
-                            <tr ng-repeat="child in vm.question.children.all" ng-init="childIndex = $index">
+                            <tr ng-repeat="child in vm.question.children.all | orderBy:matrix_position" ng-init="childIndex = $index">
                                 <td>[[child.title]]</td>
                                 <td ng-repeat ="choice in vm.question.choices.all | orderBy:['position', 'id']">
                                     <label>

--- a/formulaire/src/main/resources/public/ts/directives/question/result-question-item.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/result-question-item.ts
@@ -77,7 +77,7 @@ export const resultQuestionItem: Directive = ng.directive('resultQuestionItem', 
                                         vm.question.question_type == vm.Types.SINGLEANSWERRADIO">
                 <!-- Data -->
                 <div class="twelve-mobile" ng-class="vm.question.question_type == vm.Types.MULTIPLEANSWER ? 'twelve' : 'five'">
-                    <div ng-repeat="choice in vm.question.choices.all" class="choice">
+                    <div ng-repeat="choice in vm.question.choices.all | orderBy:['position', 'id']" class="choice">
                         <!-- Data for MULTIPLEANSWER -->
                         <div class="infos twelve-mobile" ng-class="vm.question.question_type == vm.Types.MULTIPLEANSWER  ? 'five' : 'twelve'">
                             <div class="choice-value eight twelve-mobile ellipsis">


### PR DESCRIPTION
## Describe your changes
We want choices of questions and children of matrix to be ordered always in the same way.
Some parts of the code where not forcing this ordering in ng-repeat, now it's fixed.

## Checklist tests

## Issue ticket number and link
FOR-475 : https://jira.support-ent.fr/browse/FOR-475

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)