### PR TITLE
fix(result): [FOR-474] fix percentage in multipleanswer result graph

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultDistributionService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultDistributionService.java
@@ -69,7 +69,7 @@ public class DefaultDistributionService implements DistributionService {
 
     @Override
     public void listByFormAndStatusAndQuestion(String formId, String status, String questionId, String nbLines, Handler<Either<String, JsonArray>> handler) {
-        String query = "SELECT d.* FROM " + DISTRIBUTION_TABLE + " d " +
+        String query = "SELECT DISTINCT d.* FROM " + DISTRIBUTION_TABLE + " d " +
                 "JOIN " + RESPONSE_TABLE + " r ON r.distribution_id = d.id " +
                 "WHERE form_id = ? AND status = ? AND question_id = ? " +
                 "ORDER BY date_response DESC";

--- a/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultDistributionServiceTest.java
+++ b/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultDistributionServiceTest.java
@@ -33,7 +33,7 @@ public class DefaultDistributionServiceTest {
     @Test
     public void testListByFormAndStatusAndQuestion_NbLinesNull(TestContext ctx) {
         Async async = ctx.async();
-        String expectedQuery = "SELECT d.* FROM " + DISTRIBUTION_TABLE + " d " +
+        String expectedQuery = "SELECT DISTINCT d.* FROM " + DISTRIBUTION_TABLE + " d " +
                 "JOIN " + RESPONSE_TABLE + " r ON r.distribution_id = d.id " +
                 "WHERE form_id = ? AND status = ? AND question_id = ? " +
                 "ORDER BY date_response DESC;";
@@ -52,7 +52,7 @@ public class DefaultDistributionServiceTest {
     @Test
     public void testListByFormAndStatusAndQuestion_NbLinesNotNull(TestContext ctx) {
         Async async = ctx.async();
-        String expectedQuery = "SELECT d.* FROM " + DISTRIBUTION_TABLE + " d " +
+        String expectedQuery = "SELECT DISTINCT d.* FROM " + DISTRIBUTION_TABLE + " d " +
                 "JOIN " + RESPONSE_TABLE + " r ON r.distribution_id = d.id " +
                 "WHERE form_id = ? AND status = ? AND question_id = ? " +
                 "ORDER BY date_response DESC " +


### PR DESCRIPTION
## Describe your changes
In result graph for multipleanswer the percentage were wrong on web but right on PDF export.
We corrected the SQL request who was call but returned duplicated data.

## Checklist tests

## Issue ticket number and link
FOR-474 : https://jira.support-ent.fr/browse/FOR-474

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)