### PR TITLE
fix(response) : [#FOR-510] avoid responder to respond for someone else

### DIFF
--- a/common/src/main/resources/ts/services/DistributionService.ts
+++ b/common/src/main/resources/ts/services/DistributionService.ts
@@ -2,6 +2,7 @@ import {idiom, ng, notify} from 'entcore';
 import http from 'axios';
 import {Distribution} from '../models';
 import {DataUtils} from "../utils";
+import {Mix} from "entcore-toolkit";
 
 export interface DistributionService {
     list() : Promise<any>;
@@ -11,7 +12,7 @@ export interface DistributionService {
     listByFormAndStatusAndQuestion(formId: number, status: string, questionId: number, nbLines: number) : Promise<any>
     listByFormAndResponder(formId: number) : Promise<any>;
     count(formId: number) : Promise<any>;
-    get(distributionId: number) : Promise<any>;
+    get(distributionId: number) : Promise<Distribution>;
     getByFormResponderAndStatus(formId: number) : Promise<any>;
     add(distributionId: number) : Promise<any>;
     duplicateWithResponses(distributionId: number) : Promise<any>;
@@ -84,9 +85,10 @@ export const distributionService: DistributionService = {
         }
     },
 
-    async get(distributionId: number) : Promise<any> {
+    async get(distributionId: number) : Promise<Distribution> {
         try {
-            return DataUtils.getData(await http.get(`/formulaire/distributions/${distributionId}`));
+            let data: any = DataUtils.getData(await http.get(`/formulaire/distributions/${distributionId}`));
+            return Mix.castAs(Distribution, data);
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.distributionService.get'));
             throw err;


### PR DESCRIPTION
## Describe your changes
When accessing to response page by URL, we check that the distribution corresponding is matching the connected user.
It avoids wrong people to answer the form of someone else with their link.

## Checklist tests

## Issue ticket number and link
FOR-510 : https://jira.support-ent.fr/browse/FOR-510

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)