### PR TITLE
fix(notification) : [#FOR-506] send notifications only when date_opening has passed

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/ConfigFields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/ConfigFields.java
@@ -2,6 +2,7 @@ package fr.openent.form.core.constants;
 
 public class ConfigFields {
     public static final String ZIMBRA_MAX_RECIPIENTS = "zimbra-max-recipients";
+    public static final String NOTIFY_CRON = "notify-cron";
     public static final String RGPD_CRON = "rgpd-cron";
     public static final String MAX_RESPONSE_EXPORT_PDF = "max-responses-export-PDF";
     public static final String MAX_USERS_SHARING = "max-users-sharing";

--- a/common/src/main/java/fr/openent/form/core/constants/Fields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/Fields.java
@@ -139,6 +139,7 @@ public class Fields {
     public static final String FILE = "file";
     public static final String FOLDER = "folder";
     public static final String FOLDERS = "folders";
+    public static final String FORMS = "forms";
     public static final String FORM_ELEMENTS = "form_elements";
     public static final String FORM_TILE = "form_title";
     public static final String GROUPS = "groups";

--- a/formulaire/deployment/formulaire/conf.json.template
+++ b/formulaire/deployment/formulaire/conf.json.template
@@ -18,6 +18,7 @@
     "db-schema" : "formulaire",
     "zimbra-max-recipients": ${zimbraMaxRecipients},
     "rgpd-cron": "${rgpdCron}",
+    "notify-cron": "${notifyCron}",
     "max-responses-export-PDF": ${maxResponsesExportPDF},
     "max-users-sharing": ${maxUsersSharing},
     "node-pdf-generator" : {

--- a/formulaire/src/main/java/fr/openent/formulaire/Formulaire.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/Formulaire.java
@@ -3,6 +3,7 @@ package fr.openent.formulaire;
 import fr.openent.form.core.constants.Constants;
 import fr.openent.form.core.constants.Tables;
 import fr.openent.formulaire.controllers.*;
+import fr.openent.formulaire.cron.NotifyCron;
 import fr.openent.formulaire.cron.RgpdCron;
 import fr.openent.formulaire.service.impl.FormulaireRepositoryEvents;
 import io.vertx.core.eventbus.EventBus;
@@ -95,5 +96,7 @@ public class Formulaire extends BaseServer {
 		// CRON
 		RgpdCron rgpdCron = new RgpdCron(storage);
 		new CronTrigger(vertx, config.getString(RGPD_CRON, "0 0 0 */1 * ? *")).schedule(rgpdCron);
+		NotifyCron notifyCron = new NotifyCron(timelineHelper);
+		new CronTrigger(vertx, config.getString(NOTIFY_CRON, "0 0 0 */1 * ? *")).schedule(notifyCron);
 	}
 }

--- a/formulaire/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
@@ -1,0 +1,59 @@
+package fr.openent.formulaire.cron;
+
+import fr.openent.form.helpers.UtilsHelper;
+import fr.openent.formulaire.service.*;
+import fr.openent.formulaire.service.impl.*;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.notification.TimelineHelper;
+import static fr.openent.form.core.constants.Fields.*;
+
+public class NotifyCron extends ControllerHelper implements Handler<Long> {
+    private static final Logger log = LoggerFactory.getLogger(NotifyCron.class);
+    private final FormService formService;
+    private final DistributionService distributionService;
+    private final NotifyService notifyService;
+
+    public NotifyCron(TimelineHelper timelineHelper) {
+        this.formService = new DefaultFormService();
+        this.distributionService = new DefaultDistributionService();
+        this.notifyService = new DefaultNotifyService(timelineHelper, eb);
+    }
+
+    @Override
+    public void handle(Long event) {
+        log.info("[Formulaire@NotifyCron::handle] Formulaire Notify cron started");
+        launchNotifications(notificationsEvt -> {
+            if (notificationsEvt.isLeft()) {
+                log.error("[Formulaire@NotifyCron::handle] Notify cron failed");
+            }
+            else {
+                log.info("[Formulaire@NotifyCron::handle] Notify cron launch successful");
+            }
+        });
+    }
+
+    public void launchNotifications(Handler<Either<String, JsonObject>> handler) {
+        JsonObject composeInfos = new JsonObject();
+        formService.listSentFormsOpeningToday()
+            .compose(forms -> {
+                composeInfos.put(FORMS, forms);
+                JsonArray formIds = UtilsHelper.getIds(forms);
+                return distributionService.listByForms(formIds);
+            })
+            .onSuccess(distributions -> {
+                JsonArray respondersIds = UtilsHelper.getByProp(distributions, RESPONDER_ID);
+                composeInfos.getJsonArray(FORMS).stream().forEach(form -> notifyService.notifyNewFormFromCRON((JsonObject)form, respondersIds));
+                handler.handle(new Either.Right<>(new JsonObject()));
+            })
+            .onFailure(err -> {
+                log.error("[Formulaire@NotifyCron::launchNotifications] Failed to send notifications to forms opening today.");
+                handler.handle(new Either.Left<>(err.getMessage()));
+            });
+    }
+}

--- a/formulaire/src/main/java/fr/openent/formulaire/cron/RgpdCron.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/cron/RgpdCron.java
@@ -37,13 +37,13 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
 
     @Override
     public void handle(Long event) {
-        log.info("[Formulaire@RgpdCron] Formulaire RGPD cron started");
+        log.info("[Formulaire@RgpdCron::handle] Formulaire RGPD cron started");
         deleteOldDataForRgpd(deleteEvt -> {
             if (deleteEvt.isLeft()) {
-                log.info("[Formulaire@RgpdCron] RGPD cron failed");
+                log.error("[Formulaire@RgpdCron::handle] RGPD cron failed");
             }
             else {
-                log.info("[Formulaire@RgpdCron] RGPD cron launch successful");
+                log.info("[Formulaire@RgpdCron::handle] RGPD cron launch successful");
             }
         });
     }
@@ -51,7 +51,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
     public void deleteOldDataForRgpd(Handler<Either<String, JsonObject>> handler) {
         distributionService.deleteOldDistributions(deleteDistribsEvt -> {
             if (deleteDistribsEvt.isLeft()) {
-                log.error("[Formulaire@deleteOldDataForRgpd] An error occurred while deleting distributions for old responses");
+                log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] An error occurred while deleting distributions for old responses");
                 handler.handle(new Either.Left<>(deleteDistribsEvt.left().getValue()));
                 return;
             }
@@ -65,7 +65,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
             JsonArray deletedDistribIds = getIds(deletedDistrib);
             responseService.deleteOldResponse(deletedDistribIds, deleteResponseEvt -> {
                 if (deleteResponseEvt.isLeft()) {
-                    log.error("[Formulaire@deleteOldDataForRgpd] Failed to delete old responses for RGPD forms");
+                    log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] Failed to delete old responses for RGPD forms");
                     handler.handle(new Either.Left<>(deleteResponseEvt.left().getValue()));
                     return;
                 }
@@ -80,7 +80,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
                 JsonArray deletedRepIds = getIds(deleteResponseEvt.right().getValue());
                 responseFileService.deleteAllByResponse(deletedRepIds, deleteFilesEvt -> {
                     if (deleteFilesEvt.isLeft()) {
-                        log.error("[Formulaire@deleteOldDataForRgpd] An error occurred while deleting files for responses " + deletedRepIds);
+                        log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] An error occurred while deleting files for responses " + deletedRepIds);
                         handler.handle(new Either.Left<>(deleteFilesEvt.left().getValue()));
                         return;
                     }
@@ -96,6 +96,6 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
 
     private void logDeletedDistribInfos(JsonArray deletedDistribs) {
         JsonArray distribInfos = mapByProps(deletedDistribs, new JsonArray().add(FORM_ID).add(RESPONDER_ID));
-        log.info("[Formulaire@deleteOldDataForRgpd] Distributions and response successfully deleted for : " + distribInfos);
+        log.info("[Formulaire@RgpdCron::deleteOldDataForRgpd] Distributions and response successfully deleted for : " + distribInfos);
     }
 }

--- a/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
@@ -32,6 +32,12 @@ public interface DistributionService {
     void listByForm(String formId, Handler<Either<String, JsonArray>> handler);
 
     /**
+     * List all the distributions of specific forms
+     * @param formIds form identifiers
+     */
+    Future<JsonArray> listByForms(JsonArray formIds);
+
+    /**
      * List all the distributions for a specific form sent to me
      * @param formId form identifier
      * @param user user connected

--- a/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
@@ -54,6 +54,11 @@ public interface FormService {
     void listManagers(String formId, Handler<Either<String, JsonArray>> handler);
 
     /**
+     * List all sent forms opening today
+     */
+    Future<JsonArray> listSentFormsOpeningToday();
+
+    /**
      * Get a specific form by id
      * @param formId form identifier
      * @param user user connected

--- a/formulaire/src/main/java/fr/openent/formulaire/service/NotifyService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/NotifyService.java
@@ -7,12 +7,19 @@ import io.vertx.core.json.JsonObject;
 public interface NotifyService {
 
     /**
-     * Send notification when a nwe form is distributed to a responder
+     * Send notification when a new form is distributed to a list of responders
      * @param request request
      * @param form form sent
      * @param responders ids of the responders to the form
      */
     void notifyNewForm(HttpServerRequest request, JsonObject form, JsonArray responders);
+
+    /**
+     * Send notification to a list of responders via a CRON
+     * @param form form sent
+     * @param responders ids of the responders to the form
+     */
+    void notifyNewFormFromCRON(JsonObject form, JsonArray responders);
 
     /**
      * Send notification when a response is send by a responder

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
@@ -129,6 +129,21 @@ public class DefaultFormService implements FormService {
     }
 
     @Override
+    public Future<JsonArray> listSentFormsOpeningToday() {
+        Promise<JsonArray> promise = Promise.promise();
+
+        String query = "SELECT * FROM " + FORM_TABLE + " WHERE sent = ? " +
+                "AND date_opening >= TO_CHAR(NOW(),'YYYY-MM-DD')::date " +
+                "AND date_opening < TO_CHAR(NOW() + INTERVAL '1 day','YYYY-MM-DD')::date";
+        JsonArray params = new JsonArray().add(true);
+
+        String errorMessage = "[Formulaire@DefaultFormService::listFormsOpeningToday] Fail to list forms opening today";
+        Sql.getInstance().prepared(query, params, SqlResult.validResultHandler(FutureHelper.handlerEither(promise, errorMessage)));
+
+        return promise.future();
+    }
+
+    @Override
     public Future<JsonObject> get(String formId, UserInfos user) {
         Promise<JsonObject> promise = Promise.promise();
 

--- a/formulaire/src/main/resources/i18n/timeline/en.json
+++ b/formulaire/src/main/resources/i18n/timeline/en.json
@@ -13,6 +13,7 @@
   "timeline.formulaire.lambda.sender": "A user ",
   "timeline.formulaire.responded": " has responded to the form ",
   "timeline.formulaire.sent": " has sent you a new form. ",
+  "timeline.formulaire.sent.by.unknow": "Vous avez reçu un nouveau formulaire. ",
   "timeline.formulaire.see": ". See the ",
   "timeline.formulaire.results": "results",
   "timeline.formulaire.access": "Go to the form "

--- a/formulaire/src/main/resources/i18n/timeline/fr.json
+++ b/formulaire/src/main/resources/i18n/timeline/fr.json
@@ -13,6 +13,7 @@
     "timeline.formulaire.lambda.sender": "Un utilisateur ",
     "timeline.formulaire.responded": " a répondu au formulaire ",
     "timeline.formulaire.sent": " vous a envoyé un formulaire. ",
+    "timeline.formulaire.sent.by.unknow": "Vous avez reçu un nouveau formulaire. ",
     "timeline.formulaire.see": ". Voir les ",
     "timeline.formulaire.results": "résultats",
     "timeline.formulaire.access": "Accéder au formulaire "

--- a/formulaire/src/main/resources/view-src/notify/new_form_notification.html
+++ b/formulaire/src/main/resources/view-src/notify/new_form_notification.html
@@ -1,14 +1,14 @@
 <span>{{#i18n}}timeline.formulaire.new.notification{{/i18n}}</span>
-{{#userUri}}<a href="{{#host}}{{userUri}}{{/host}}">{{username}}</a>{{/userUri}}
+{{#userUri}}
+ <span>{{#i18n}}timeline.formulaire.from{{/i18n}}</span><a href="{{#host}}{{userUri}}{{/host}}">{{username}}</a>
+{{/userUri}}
 {{^userUri}}
- {{#username}}{{username}}{{/username}}
- {{^username}}<span>{{#i18n}}timeline.unknown.sender{{/i18n}}</span>{{/username}}
+ {{#username}}<span>{{#i18n}}timeline.formulaire.from{{/i18n}}</span>{{username}}{{/username}}
 {{/userUri}}
  :<br/>
 
-{{#username}}{{username}}{{/username}}
-{{^username}}<span>{{#i18n}}timeline.unknown.sender{{/i18n}}</span>{{/username}}
-<span>{{#i18n}}timeline.formulaire.sent{{/i18n}}</span>
+{{#username}}{{username}}<span>{{#i18n}}timeline.formulaire.sent{{/i18n}}</span>{{/username}}
+{{^username}}<span>{{#i18n}}timeline.formulaire.sent.by.unknow{{/i18n}}</span>{{/username}}
 {{#formUri}}
  {{#formName}}
   <span>{{#i18n}}timeline.formulaire.access{{/i18n}}</span>


### PR DESCRIPTION
## Describe your changes
- block notifications when formulaire is sent before opening date
- new CRON starting every day at midnight and sending notifications for all the forms sent but having an opening date define to this day -> for example a form created and sent the 6th but having an opening date defined for the 8th will have notifications sent by the CRON the 8th at 00h00
- improve text and template of notifications

## Checklist tests

## Issue ticket number and link
FOR-506 : https://jira.support-ent.fr/browse/FOR-506

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)