### PR TITLE
fix(date_opening): [#FOR-527] fix dates format before sending to the back

### DIFF
--- a/common/src/main/resources/ts/core/constants/date_formats.ts
+++ b/common/src/main/resources/ts/core/constants/date_formats.ts
@@ -1,0 +1,3 @@
+export abstract class DateFormats {
+    static readonly YYYY_MM_DD_T_HH_mm_ss: string = 'YYYY-MM-DDTHH:mm:ss';
+}

--- a/common/src/main/resources/ts/core/constants/index.ts
+++ b/common/src/main/resources/ts/core/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './constants';
+export * from './date_formats';
 export * from './fields';

--- a/common/src/main/resources/ts/services/FormService.ts
+++ b/common/src/main/resources/ts/services/FormService.ts
@@ -3,6 +3,7 @@ import http from 'axios';
 import {Form} from '../models';
 import {DataUtils} from "../utils";
 import {Exports} from "../core/enums";
+import {DateFormats} from "@common/core/constants";
 
 export interface FormService {
     list() : Promise<any>;
@@ -64,10 +65,10 @@ export const formService: FormService = {
 
     async save(form: Form) : Promise<any> {
         if (form.date_opening != null) {
-            form.date_opening = moment(form.date_opening.setHours(0,0,0,0));
+            form.date_opening = moment(form.date_opening.setHours(0,0,0,0)).format(DateFormats.YYYY_MM_DD_T_HH_mm_ss);
         }
         if (form.date_ending != null) {
-            form.date_ending = moment(form.date_ending.setHours(23,59,59,999));
+            form.date_ending = moment(form.date_ending.setHours(23,59,59,999)).format(DateFormats.YYYY_MM_DD_T_HH_mm_ss);
         }
         return form.id ? await this.update(form) : await this.create(form);
     },


### PR DESCRIPTION
## Describe your changes
When sending a moment object to the back it converts timezone to UTC without timezone.
We changed the format in front to have the correct date in BDD

## Checklist tests

## Issue ticket number and link
FOR-527 : https://jira.support-ent.fr/browse/FOR-527

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)