### PR TITLE
fix(reminder): [#FOR-487] fix form prop SENT when value is wrong

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/ConfigFields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/ConfigFields.java
@@ -2,6 +2,7 @@ package fr.openent.form.core.constants;
 
 public class ConfigFields {
     public static final String ZIMBRA_MAX_RECIPIENTS = "zimbra-max-recipients";
+    public static final String NOTIFY_CRON = "notify-cron";
     public static final String RGPD_CRON = "rgpd-cron";
     public static final String MAX_RESPONSE_EXPORT_PDF = "max-responses-export-PDF";
     public static final String MAX_USERS_SHARING = "max-users-sharing";

--- a/common/src/main/java/fr/openent/form/core/constants/Fields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/Fields.java
@@ -139,6 +139,7 @@ public class Fields {
     public static final String FILE = "file";
     public static final String FOLDER = "folder";
     public static final String FOLDERS = "folders";
+    public static final String FORMS = "forms";
     public static final String FORM_ELEMENTS = "form_elements";
     public static final String FORM_TILE = "form_title";
     public static final String GROUPS = "groups";

--- a/common/src/main/resources/ts/core/constants/date_formats.ts
+++ b/common/src/main/resources/ts/core/constants/date_formats.ts
@@ -1,0 +1,3 @@
+export abstract class DateFormats {
+    static readonly YYYY_MM_DD_T_HH_mm_ss: string = 'YYYY-MM-DDTHH:mm:ss';
+}

--- a/common/src/main/resources/ts/core/constants/index.ts
+++ b/common/src/main/resources/ts/core/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './constants';
+export * from './date_formats';
 export * from './fields';

--- a/common/src/main/resources/ts/directives/rgpd.ts
+++ b/common/src/main/resources/ts/directives/rgpd.ts
@@ -1,65 +1,98 @@
-import {Directive, idiom, ng} from "entcore";
+import {idiom, ng} from "entcore";
 import {Delegate, Delegates, Form} from "../models";
 import {I18nUtils} from "../utils";
+import {IScope} from "angular";
+import {FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
 
-interface IViewModel {
+interface IRgpdProps {
+    form: Form;
+    delegates: Delegates;
+}
+
+interface IViewModel extends ng.IController, IRgpdProps {
+    init(): Promise<void>;
+    getHtmlDescription(description: string): string;
+    getRgpdDescriptionIntro(): string;
+    getRgpdDescriptionDelegates(delegate: Delegate): string;
+    getEndValidityDate(): string;
+}
+
+interface IRgpdScope extends IScope, IRgpdProps {
+    vm: IViewModel;
+}
+
+class Controller implements IViewModel {
     form: Form;
     delegates: Delegates;
 
-    $onInit() : Promise<void>;
-    getRgpdDescriptionIntro() : string;
-    getRgpdDescriptionDelegates(delegate: Delegate) : string;
+    constructor(private $scope: IRgpdScope, private $sce: ng.ISCEService) {}
+
+    $onInit = async () : Promise<void> => {
+        await this.init();
+    }
+
+    $onDestroy = async (): Promise<void> => {}
+
+    init = async (): Promise<void> => {
+        this.delegates = new Delegates();
+        await this.delegates.sync();
+        this.$scope.$on(FORMULAIRE_FORM_ELEMENT_EMIT_EVENT.REFRESH_QUESTION, () => { this.init(); });
+        this.$scope.$apply();
+    }
+
+    getHtmlDescription = (description: string): string => {
+        return !!description ? this.$sce.trustAsHtml(description): null;
+    }
+
+    getRgpdDescriptionIntro = () : string => {
+        let defaultGoal: string = "[" + idiom.translate('formulaire.prop.rgpd.goal') + "]";
+        let params: string[] = [this.form.rgpd_goal ? this.form.rgpd_goal : defaultGoal, this.getEndValidityDate()];
+        return I18nUtils.getWithParams('formulaire.prop.rgpd.description.intro', params);
+    }
+
+    getRgpdDescriptionDelegates = (delegate: Delegate) : string => {
+        let params: string[] = [delegate.entity, delegate.mail, delegate.address, delegate.zipcode, delegate.city];
+        for (let i = 0; i < params.length; i++) {
+            if (params[i] == null) {
+                params[i] = "";
+            }
+        }
+        let delegateDescription: string = I18nUtils.getWithParams('formulaire.prop.rgpd.description.delegates', params);
+        return this.getHtmlDescription(delegateDescription);
+    }
+
+    getEndValidityDate = () : string => {
+        let today: Date = new Date();
+        today.setMonth(today.getMonth() + this.form.rgpd_lifetime);
+        return today.toLocaleDateString();
+    }
 }
 
-export const rgpd: Directive = ng.directive('rgpd', () => {
-
+function directive() {
     return {
         restrict: 'E',
+        transclude: true,
         scope: {
-            form: '='
+            question: '=',
+            response: '=',
+            selectedIndexes: '='
         },
         controllerAs: 'vm',
         bindToController: true,
         template: `
             <div class="rgpd">
-                <div class="bottom-spacing-three" ng-bind-html="vm.getRgpdDescriptionIntro()"></div>
-                <div ng-repeat="delegate in vm.delegates.all" ng-bind-html="vm.getRgpdDescriptionDelegates(delegate)"></div>
+                <div class="bottom-spacing-three" data-ng-bind-html="vm.getHtmlDescription(vm.getRgpdDescriptionIntro())"></div>
+                <div ng-repeat="delegate in vm.delegates.all" data-ng-bind-html="vm.getRgpdDescriptionDelegates(delegate)"></div>
             </div>
         `,
-
-        controller: function($scope) {
-            const vm: IViewModel = <IViewModel> this;
-
-            vm.$onInit = async () : Promise<void> => {
-                vm.delegates = new Delegates();
-                await vm.delegates.sync();
-                $scope.$apply();
-            };
-        },
-        link: function ($scope, $element) {
-            const vm: IViewModel = $scope.vm;
-
-            vm.getRgpdDescriptionIntro = () : string => {
-                let defaultGoal = "[" + idiom.translate('formulaire.prop.rgpd.goal') + "]";
-                let params = [vm.form.rgpd_goal ? vm.form.rgpd_goal : defaultGoal, getEndValidityDate()];
-                return I18nUtils.getWithParams('formulaire.prop.rgpd.description.intro', params);
-            };
-
-            vm.getRgpdDescriptionDelegates = (delegate) : string => {
-                let params = [delegate.entity, delegate.mail, delegate.address, delegate.zipcode, delegate.city];
-                for(let i = 0; i < params.length; i++){
-                    if(params[i] == null){
-                        params[i] = "";
-                    }
-                }
-                return I18nUtils.getWithParams('formulaire.prop.rgpd.description.delegates', params);
-            };
-
-            const getEndValidityDate = () : string => {
-                let today = new Date();
-                today.setMonth(today.getMonth() + vm.form.rgpd_lifetime);
-                return today.toLocaleDateString();
-            };
+        controller: ['$scope', '$sce', Controller],
+        /* interaction DOM/element */
+        link: function ($scope: IRgpdScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: IViewModel) {
         }
-    };
-});
+    }
+}
+
+export const rgpd = ng.directive('rgpd', directive);

--- a/common/src/main/resources/ts/models/Distribution.ts
+++ b/common/src/main/resources/ts/models/Distribution.ts
@@ -83,12 +83,10 @@ export class Distributions {
 
     syncByFormAndResponder = async (formId: number) : Promise<void> => {
         try {
-            let data = await distributionService.listByFormAndResponder(formId);
-            this.all = Mix.castArrayAs(Distribution, data);
-            for (let i = this.all.length - 1; i >= this.all.length - data.length; i--) {
-                let distrib = this.all[i];
-                distrib.date_response = new Date(distrib.date_response);
-                distrib.date_sending = new Date(distrib.date_sending);
+            this.all = await distributionService.listByFormAndResponder(formId);
+            for (let distribution of this.all) {
+                distribution.date_response = new Date(distribution.date_response);
+                distribution.date_sending = new Date(distribution.date_sending);
             }
         } catch (e) {
             notify.error(idiom.translate('formulaire.error.distribution.sync'));

--- a/common/src/main/resources/ts/services/DistributionService.ts
+++ b/common/src/main/resources/ts/services/DistributionService.ts
@@ -10,7 +10,7 @@ export interface DistributionService {
     listByForm(formId: number) : Promise<any>;
     listByFormAndStatus(formId: number, status: string, nbLines: number) : Promise<any>;
     listByFormAndStatusAndQuestion(formId: number, status: string, questionId: number, nbLines: number) : Promise<any>
-    listByFormAndResponder(formId: number) : Promise<any>;
+    listByFormAndResponder(formId: number) : Promise<Distribution[]>;
     count(formId: number) : Promise<any>;
     get(distributionId: number) : Promise<Distribution>;
     getByFormResponderAndStatus(formId: number) : Promise<any>;
@@ -67,9 +67,10 @@ export const distributionService: DistributionService = {
         }
     },
 
-    async listByFormAndResponder(formId: number) : Promise<any> {
+    async listByFormAndResponder(formId: number) : Promise<Distribution[]> {
         try {
-            return DataUtils.getData(await http.get(`/formulaire/distributions/forms/${formId}/listMine`));
+            let data: any = DataUtils.getData(await http.get(`/formulaire/distributions/forms/${formId}/listMine`));
+            return Mix.castArrayAs(Distribution, data);
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.distributionService.list'));
             throw err;

--- a/common/src/main/resources/ts/services/DistributionService.ts
+++ b/common/src/main/resources/ts/services/DistributionService.ts
@@ -2,6 +2,7 @@ import {idiom, ng, notify} from 'entcore';
 import http from 'axios';
 import {Distribution} from '../models';
 import {DataUtils} from "../utils";
+import {Mix} from "entcore-toolkit";
 
 export interface DistributionService {
     list() : Promise<any>;
@@ -11,7 +12,7 @@ export interface DistributionService {
     listByFormAndStatusAndQuestion(formId: number, status: string, questionId: number, nbLines: number) : Promise<any>
     listByFormAndResponder(formId: number) : Promise<any>;
     count(formId: number) : Promise<any>;
-    get(distributionId: number) : Promise<any>;
+    get(distributionId: number) : Promise<Distribution>;
     getByFormResponderAndStatus(formId: number) : Promise<any>;
     add(distributionId: number) : Promise<any>;
     duplicateWithResponses(distributionId: number) : Promise<any>;
@@ -84,9 +85,10 @@ export const distributionService: DistributionService = {
         }
     },
 
-    async get(distributionId: number) : Promise<any> {
+    async get(distributionId: number) : Promise<Distribution> {
         try {
-            return DataUtils.getData(await http.get(`/formulaire/distributions/${distributionId}`));
+            let data: any = DataUtils.getData(await http.get(`/formulaire/distributions/${distributionId}`));
+            return Mix.castAs(Distribution, data);
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.distributionService.get'));
             throw err;

--- a/common/src/main/resources/ts/services/FormService.ts
+++ b/common/src/main/resources/ts/services/FormService.ts
@@ -3,6 +3,7 @@ import http from 'axios';
 import {Form} from '../models';
 import {DataUtils} from "../utils";
 import {Exports} from "../core/enums";
+import {DateFormats} from "@common/core/constants";
 
 export interface FormService {
     list() : Promise<any>;
@@ -64,10 +65,10 @@ export const formService: FormService = {
 
     async save(form: Form) : Promise<any> {
         if (form.date_opening != null) {
-            form.date_opening = moment(form.date_opening.setHours(0,0,0,0));
+            form.date_opening = moment(form.date_opening.setHours(0,0,0,0)).format(DateFormats.YYYY_MM_DD_T_HH_mm_ss);
         }
         if (form.date_ending != null) {
-            form.date_ending = moment(form.date_ending.setHours(23,59,59,999));
+            form.date_ending = moment(form.date_ending.setHours(23,59,59,999)).format(DateFormats.YYYY_MM_DD_T_HH_mm_ss);
         }
         return form.id ? await this.update(form) : await this.create(form);
     },

--- a/formulaire-public/deployment/formulaire-public/conf.json.template
+++ b/formulaire-public/deployment/formulaire-public/conf.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "fr.openent~formulaire-public~1.6.2",
+  "name": "fr.openent~formulaire-public~1.6-SNAPSHOT",
   "config": {
     "main" : "fr.openent.formulaire_public.FormulairePublic",
     "port" : 8077,

--- a/formulaire-public/deployment/formulaire-public/conf.json.template
+++ b/formulaire-public/deployment/formulaire-public/conf.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "fr.openent~formulaire-public~1.6.1",
+  "name": "fr.openent~formulaire-public~1.6.2",
   "config": {
     "main" : "fr.openent.formulaire_public.FormulairePublic",
     "port" : 8077,

--- a/formulaire-public/src/main/java/fr/openent/formulaire_public/service/impl/DefaultNotifyService.java
+++ b/formulaire-public/src/main/java/fr/openent/formulaire_public/service/impl/DefaultNotifyService.java
@@ -17,11 +17,13 @@ public class DefaultNotifyService implements NotifyService {
 
     @Override
     public void notifyResponse(HttpServerRequest request, JsonObject form, JsonArray managers) {
+        String formResultsUri = "/formulaire#/form/" + form.getInteger(ID) + "/results/1";
         JsonObject params = new JsonObject()
                 .put(PARAM_FORM_URI, "/formulaire#/form/" + form.getInteger(ID) + "/edit")
                 .put(PARAM_FORM_NAME, form.getString(TITLE))
-                .put(PARAM_FORM_RESULTS_URI, "/formulaire#/form/" + form.getInteger(ID) + "/results/1")
-                .put(PARAM_PUSH_NOTIF, new JsonObject().put(TITLE, "push.notif.formulaire.public.response").put(BODY, ""));
+                .put(PARAM_FORM_RESULTS_URI, formResultsUri)
+                .put(PARAM_PUSH_NOTIF, new JsonObject().put(TITLE, "push.notif.formulaire.public.response").put(BODY, ""))
+                .put(PARAM_RESOURCE_URI, formResultsUri);
 
         timelineHelper.notifyTimeline(request, "formulaire-public.response_notification", null, managers.getList(), params);
     }

--- a/formulaire-public/src/main/resources/public/template/containers/recap.html
+++ b/formulaire-public/src/main/resources/public/template/containers/recap.html
@@ -28,7 +28,7 @@
                     <div class="section-top">
                         <div class="title"><h4>[[formElement.title]]</h4></div>
                         <div class="description" ng-if="formElement.description">
-                            <div ng-bind-html="formElement.description"></div>
+                            <div data-ng-bind-html="vm.getHtmlDescription(formElement.description)"></div>
                         </div>
                     </div>
                     <div class="section-main">

--- a/formulaire-public/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire-public/src/main/resources/public/template/containers/respond-question.html
@@ -30,7 +30,7 @@
                 <div class="section-top">
                     <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                     <div class="description" ng-if="vm.formElement.description">
-                        <div ng-bind-html="vm.formElement.description"></div>
+                        <div data-ng-bind-html="vm.getHtmlDescription(vm.formElement.description)"></div>
                     </div>
                 </div>
                 <div class="section-main">

--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -4,7 +4,7 @@ import {
 	FormElement,
 	FormElements,
 	Question,
-	QuestionChoice, Questions,
+	QuestionChoice,
 	Response,
 	Responses,
 	Section,
@@ -28,10 +28,11 @@ interface ViewModel {
 	$onInit(): Promise<void>;
 	prev() : void;
 	next() : void;
+	getHtmlDescription(description: string) : string;
 }
 
-export const respondQuestionController = ng.controller('RespondQuestionController', ['$scope',
-	function ($scope) {
+export const respondQuestionController = ng.controller('RespondQuestionController', ['$scope', '$sce',
+	function ($scope, $sce) {
 
 	const vm: ViewModel = this;
 	vm.form = new Form();
@@ -71,6 +72,10 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			template.open('main', 'containers/recap');
 		}
 	};
+
+	vm.getHtmlDescription = (description: string) : string => {
+		return !!description ? $sce.trustAsHtml(description) : null;
+	}
 
 	// Utils
 

--- a/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
+++ b/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
@@ -1,23 +1,55 @@
-import {Directive, ng} from "entcore";
-import {
-    Question,
-    Response,
-    Types
-} from "@common/models";
-import { FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
+import {ng} from "entcore";
+import {Question, Response, Types} from "@common/models";
+import {FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
 import {I18nUtils} from "@common/utils";
+import {IScope} from "angular";
 
-interface IViewModel {
+interface IPublicQuestionItemProps {
     question: Question;
     response: Response;
     selectedIndexes: boolean[];
     Types: typeof Types;
     I18n: I18nUtils;
-
-    $onInit() : Promise<void>;
 }
 
-export const publicQuestionItem: Directive = ng.directive('publicQuestionItem', () => {
+interface IViewModel extends ng.IController, IPublicQuestionItemProps {
+    init(): Promise<void>;
+    getHtmlDescription(description: string): string;
+}
+
+interface IPublicQuestionItemScope extends IScope, IPublicQuestionItemProps {
+    vm: IViewModel;
+}
+
+class Controller implements IViewModel {
+    question: Question;
+    response: Response;
+    selectedIndexes: boolean[];
+    Types = Types;
+    I18n = I18nUtils;
+
+    constructor(private $scope: IPublicQuestionItemScope, private $sce: ng.ISCEService) {}
+
+    $onInit = async () : Promise<void> => {
+        await this.init();
+    }
+
+    $onDestroy = async (): Promise<void> => {}
+
+    init = async () : Promise<void> => {
+        if (!this.response.question_id) { this.response.question_id = this.question.id; }
+        if (this.question.question_type === Types.TIME && this.response.answer) {
+            this.response.answer = new Date("January 01 1970 " + this.response.answer);
+        }
+        this.$scope.$on(FORMULAIRE_FORM_ELEMENT_EMIT_EVENT.REFRESH_QUESTION, () => { this.init(); });
+    }
+
+    getHtmlDescription = (description: string): string => {
+        return !!description ? this.$sce.trustAsHtml(description) : null;
+    }
+}
+
+function directive() {
     return {
         restrict: 'E',
         transclude: true,
@@ -35,7 +67,7 @@ export const publicQuestionItem: Directive = ng.directive('publicQuestionItem', 
                 </div>
                 <div class="question-main">
                     <div ng-if="vm.question.question_type == vm.Types.FREETEXT">
-                        <div ng-if="vm.question.statement" ng-bind-html="vm.question.statement"></div>
+                        <div ng-if="vm.question.statement" data-ng-bind-html="vm.getHtmlDescription(vm.question.statement)"></div>
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.SHORTANSWER">
                         <textarea ng-model="vm.response.answer" i18n-placeholder="[[vm.question.placeholder]]" input-guard></textarea>
@@ -73,23 +105,14 @@ export const publicQuestionItem: Directive = ng.directive('publicQuestionItem', 
                 </div>
             </div>
         `,
-
-        controller: function ($scope) {
-            const vm: IViewModel = <IViewModel> this;
-
-            vm.$onInit = async () : Promise<void> => {
-                if (!vm.response.question_id) { vm.response.question_id = vm.question.id; }
-                if (vm.question.question_type === Types.TIME && vm.response.answer) {
-                    vm.response.answer = new Date("January 01 1970 " + vm.response.answer);
-                }
-            };
-        },
-        link: function ($scope, $element) {
-            const vm: IViewModel = $scope.vm;
-            vm.Types = Types;
-            vm.I18n = I18nUtils;
-
-            $scope.$on(FORMULAIRE_FORM_ELEMENT_EMIT_EVENT.REFRESH_QUESTION, () => { vm.$onInit(); });
+        controller: ['$scope', '$sce', Controller],
+        /* interaction DOM/element */
+        link: function ($scope: IPublicQuestionItemScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: IViewModel) {
         }
-    };
-});
+    }
+}
+
+export const publicQuestionItem = ng.directive('publicQuestionItem', directive);

--- a/formulaire/deployment/formulaire/conf.json.template
+++ b/formulaire/deployment/formulaire/conf.json.template
@@ -18,6 +18,7 @@
     "db-schema" : "formulaire",
     "zimbra-max-recipients": ${zimbraMaxRecipients},
     "rgpd-cron": "${rgpdCron}",
+    "notify-cron": "${notifyCron}",
     "max-responses-export-PDF": ${maxResponsesExportPDF},
     "max-users-sharing": ${maxUsersSharing},
     "node-pdf-generator" : {

--- a/formulaire/deployment/formulaire/conf.json.template
+++ b/formulaire/deployment/formulaire/conf.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "fr.openent~formulaire~1.6.1",
+  "name": "fr.openent~formulaire~1.6.2",
   "config": {
     "main" : "fr.openent.formulaire.Formulaire",
     "port" : 8067,

--- a/formulaire/deployment/formulaire/conf.json.template
+++ b/formulaire/deployment/formulaire/conf.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "fr.openent~formulaire~1.6.2",
+  "name": "fr.openent~formulaire~1.6-SNAPSHOT",
   "config": {
     "main" : "fr.openent.formulaire.Formulaire",
     "port" : 8067,

--- a/formulaire/src/main/java/fr/openent/formulaire/Formulaire.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/Formulaire.java
@@ -3,6 +3,7 @@ package fr.openent.formulaire;
 import fr.openent.form.core.constants.Constants;
 import fr.openent.form.core.constants.Tables;
 import fr.openent.formulaire.controllers.*;
+import fr.openent.formulaire.cron.NotifyCron;
 import fr.openent.formulaire.cron.RgpdCron;
 import fr.openent.formulaire.service.impl.FormulaireRepositoryEvents;
 import io.vertx.core.eventbus.EventBus;
@@ -95,5 +96,7 @@ public class Formulaire extends BaseServer {
 		// CRON
 		RgpdCron rgpdCron = new RgpdCron(storage);
 		new CronTrigger(vertx, config.getString(RGPD_CRON, "0 0 0 */1 * ? *")).schedule(rgpdCron);
+		NotifyCron notifyCron = new NotifyCron(timelineHelper);
+		new CronTrigger(vertx, config.getString(NOTIFY_CRON, "0 0 0 */1 * ? *")).schedule(notifyCron);
 	}
 }

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -162,7 +162,13 @@ public class FormController extends ControllerHelper {
             if (user.getGroupsIds() != null) {
                 groupsAndUserIds.addAll(user.getGroupsIds());
             }
-            formService.listForLinker(groupsAndUserIds, user, arrayResponseHandler(request));
+
+            formService.listForLinker(groupsAndUserIds, user)
+                .onSuccess(result -> renderJson(request, result))
+                .onFailure(err -> {
+                    log.error(err.getMessage());
+                    renderError(request);
+                });
         });
     }
 

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -922,129 +922,140 @@ public class FormController extends ControllerHelper {
         String formId = request.getParam(PARAM_FORM_ID);
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
-                String message = "[Formulaire@sendReminder] User not found in session.";
+                String message = "[Formulaire@FormController::sendReminder] User not found in session.";
                 log.error(message);
-                unauthorized(request, message);
+                unauthorized(request);
                 return;
             }
 
             RequestUtils.bodyToJson(request, mail -> {
                 if (mail == null || mail.isEmpty()) {
-                    log.error("[Formulaire@sendReminder] No mail to send.");
+                    log.error("[Formulaire@FormController::sendReminder] No mail to send.");
                     noContent(request);
                     return;
                 }
 
                 formService.get(formId, user, formEvt -> {
                     if (formEvt.isLeft()) {
-                        log.error("[Formulaire@sendReminder] Fail to get form " + formId + " : " + formEvt.left().getValue());
+                        log.error("[Formulaire@FormController::sendReminder] Fail to get form " + formId + " : " + formEvt.left().getValue());
                         renderInternalError(request, formEvt);
                         return;
                     }
                     if (formEvt.right().getValue().isEmpty()) {
-                        String message = "[Formulaire@sendReminder] No form found for id " + formId;
+                        String message = "[Formulaire@FormController::sendReminder] No form found for id " + formId;
                         log.error(message);
-                        notFound(request, message);
+                        notFound(request);
                         return;
                     }
 
-                    // Should not send reminder if form is not sent
                     JsonObject form = formEvt.right().getValue();
-                    if (!form.getBoolean(SENT)) {
-                        String message = "[Formulaire@sendReminder] You cannot send a reminder for a form which is not already send for response.";
-                        log.error(message);
-                        badRequest(request, message);
-                        return;
-                    }
-
                     distributionService.listByForm(formId, distributionsEvt -> {
                         if (distributionsEvt.isLeft()) {
-                            log.error("[Formulaire@sendReminder] Fail to retrieve distributions for form with id : " + formId);
+                            log.error("[Formulaire@FormController::sendReminder] Fail to retrieve distributions for form with id : " + formId);
                             renderInternalError(request, distributionsEvt);
                             return;
                         }
                         if (distributionsEvt.right().getValue().isEmpty()) {
-                            String message = "[Formulaire@sendReminder] No distributions found for form with id " + formId;
+                            String message = "[Formulaire@FormController::sendReminder] No distributions found for form with id " + formId;
                             log.error(message);
-                            notFound(request, message);
+                            notFound(request);
                             return;
                         }
 
                         JsonArray distributions = distributionsEvt.right().getValue();
-                        JsonArray localRespondersIds = new JsonArray();
-                        JsonArray listMails = new JsonArray();
 
-                        // Generate list of mails to send
-                        for (int i = 0; i < distributions.size(); i++) {
-                            String id = distributions.getJsonObject(i).getString(RESPONDER_ID);
-                            if (!localRespondersIds.contains(id)) {
-                                if (form.getBoolean(MULTIPLE) || form.getBoolean(ANONYMOUS) ||
-                                    distributions.getJsonObject(i).getString(DATE_RESPONSE) == null) {
-                                    localRespondersIds.add(id);
-                                }
-                            }
-
-                            // Generate new mail object if limit or end loop are reached
-                            if (i == distributions.size() - 1 || localRespondersIds.size() == config.getInteger(ZIMBRA_MAX_RECIPIENTS, 50)) {
-                                JsonObject message = new JsonObject()
-                                        .put(SUBJECT, mail.getString(SUBJECT, ""))
-                                        .put(BODY, mail.getString(BODY, ""))
-                                        .put(TO, new JsonArray())
-                                        .put(CCI, localRespondersIds);
-
-                                JsonObject action = new JsonObject()
-                                        .put(ACTION, SEND)
-                                        .put(PARAM_USER_ID, user.getUserId())
-                                        .put(USERNAME, user.getUsername())
-                                        .put(MESSAGE, message);
-
-                                listMails.add(action);
-                                localRespondersIds = new JsonArray();
-                            }
-                        }
-
-
-                        // Prepare futures to get message responses
-                        List<Future> mails = new ArrayList<>();
-
-                        // Code to send mails
-                        for (int i = 0; i < listMails.size(); i++) {
-                            Future future = Promise.promise().future();
-                            mails.add(future);
-
-                            // Send mail via Conversation app if it exists or else with Zimbra
-                            eb.request(CONVERSATION_ADDRESS, listMails.getJsonObject(i), (Handler<AsyncResult<Message<JsonObject>>>) messageEvt -> {
-                                if (!messageEvt.result().body().getString(STATUS).equals(OK)) {
-                                    log.error("[Formulaire@sendReminder] Failed to send reminder : " + messageEvt.cause());
-                                    future.handle(Future.failedFuture(messageEvt.cause()));
-                                }
-                                else {
-                                    future.handle(Future.succeededFuture(messageEvt.result().body()));
-                                }
-                            });
-                        }
-
-                        // Try to send effectively mails with code below and get results
-                        CompositeFuture.all(mails).onComplete(sendMailsEvt -> {
-                            if (sendMailsEvt.failed()) {
-                                log.error("[Formulaire@sendReminder] Failed to send reminder : " + sendMailsEvt.cause());
-                                renderInternalError(request, sendMailsEvt);
-                                return;
-                            }
-
-                            // Update 'reminded' prop of the form
-                            form.put(REMINDED, true);
-                            formService.update(formId, form, updateEvt -> {
-                                if (updateEvt.isLeft()) {
-                                    log.error("[Formulaire@sendReminder] Fail to update form " + formId + " : " + updateEvt.left().getValue());
-                                    renderInternalError(request, updateEvt);
+                        // If form prop is not consistent with number of distributions
+                        if (!form.getBoolean(SENT)) {
+                            form.put(SENT, true);
+                            formService.update(formId, form, updatedFormEvt -> {
+                                if (formEvt.isLeft()) {
+                                    log.error("[Formulaire@FormController::sendReminder] Fail to update form " + formId + " : " + formEvt.left().getValue());
+                                    renderInternalError(request, formEvt);
                                     return;
                                 }
-                                renderJson(request, updateEvt.right().getValue());
+
+                                doSendReminder(request, formId, form, distributions, mail, user);
                             });
-                        });
+                        }
+
+                        doSendReminder(request, formId, form, distributions, mail, user);
                     });
                 });
+            });
+        });
+    }
+
+    private void doSendReminder(HttpServerRequest request, String formId, JsonObject form, JsonArray distributions, JsonObject mail, UserInfos user) {
+        JsonArray localRespondersIds = new JsonArray();
+        JsonArray listMails = new JsonArray();
+
+        // Generate list of mails to send
+        for (int i = 0; i < distributions.size(); i++) {
+            String id = distributions.getJsonObject(i).getString(RESPONDER_ID);
+            if (!localRespondersIds.contains(id)) {
+                if (form.getBoolean(MULTIPLE) || form.getBoolean(ANONYMOUS) ||
+                        distributions.getJsonObject(i).getString(DATE_RESPONSE) == null) {
+                    localRespondersIds.add(id);
+                }
+            }
+
+            // Generate new mail object if limit or end loop are reached
+            if (i == distributions.size() - 1 || localRespondersIds.size() == config.getInteger(ZIMBRA_MAX_RECIPIENTS, 50)) {
+                JsonObject message = new JsonObject()
+                        .put(SUBJECT, mail.getString(SUBJECT, ""))
+                        .put(BODY, mail.getString(BODY, ""))
+                        .put(TO, new JsonArray())
+                        .put(CCI, localRespondersIds);
+
+                JsonObject action = new JsonObject()
+                        .put(ACTION, SEND)
+                        .put(PARAM_USER_ID, user.getUserId())
+                        .put(USERNAME, user.getUsername())
+                        .put(MESSAGE, message);
+
+                listMails.add(action);
+                localRespondersIds = new JsonArray();
+            }
+        }
+
+
+        // Prepare futures to get message responses
+        List<Future> mails = new ArrayList<>();
+
+        // Code to send mails
+        for (int i = 0; i < listMails.size(); i++) {
+            Future future = Promise.promise().future();
+            mails.add(future);
+
+            // Send mail via Conversation app if it exists or else with Zimbra
+            eb.request(CONVERSATION_ADDRESS, listMails.getJsonObject(i), (Handler<AsyncResult<Message<JsonObject>>>) messageEvt -> {
+                if (!messageEvt.result().body().getString(STATUS).equals(OK)) {
+                    log.error("[Formulaire@FormController::sendReminder] Failed to send reminder : " + messageEvt.cause());
+                    future.handle(Future.failedFuture(messageEvt.cause()));
+                }
+                else {
+                    future.handle(Future.succeededFuture(messageEvt.result().body()));
+                }
+            });
+        }
+
+        // Try to send effectively mails with code below and get results
+        CompositeFuture.all(mails).onComplete(sendMailsEvt -> {
+            if (sendMailsEvt.failed()) {
+                log.error("[Formulaire@FormController::sendReminder] Failed to send reminder : " + sendMailsEvt.cause());
+                renderInternalError(request, sendMailsEvt);
+                return;
+            }
+
+            // Update 'reminded' prop of the form
+            form.put(REMINDED, true);
+            formService.update(formId, form, updateEvt -> {
+                if (updateEvt.isLeft()) {
+                    log.error("[Formulaire@FormController::sendReminder] Fail to update form " + formId + " : " + updateEvt.left().getValue());
+                    renderInternalError(request, updateEvt);
+                    return;
+                }
+                renderJson(request, updateEvt.right().getValue());
             });
         });
     }

--- a/formulaire/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
@@ -1,0 +1,59 @@
+package fr.openent.formulaire.cron;
+
+import fr.openent.form.helpers.UtilsHelper;
+import fr.openent.formulaire.service.*;
+import fr.openent.formulaire.service.impl.*;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.notification.TimelineHelper;
+import static fr.openent.form.core.constants.Fields.*;
+
+public class NotifyCron extends ControllerHelper implements Handler<Long> {
+    private static final Logger log = LoggerFactory.getLogger(NotifyCron.class);
+    private final FormService formService;
+    private final DistributionService distributionService;
+    private final NotifyService notifyService;
+
+    public NotifyCron(TimelineHelper timelineHelper) {
+        this.formService = new DefaultFormService();
+        this.distributionService = new DefaultDistributionService();
+        this.notifyService = new DefaultNotifyService(timelineHelper, eb);
+    }
+
+    @Override
+    public void handle(Long event) {
+        log.info("[Formulaire@NotifyCron::handle] Formulaire Notify cron started");
+        launchNotifications(notificationsEvt -> {
+            if (notificationsEvt.isLeft()) {
+                log.error("[Formulaire@NotifyCron::handle] Notify cron failed");
+            }
+            else {
+                log.info("[Formulaire@NotifyCron::handle] Notify cron launch successful");
+            }
+        });
+    }
+
+    public void launchNotifications(Handler<Either<String, JsonObject>> handler) {
+        JsonObject composeInfos = new JsonObject();
+        formService.listSentFormsOpeningToday()
+            .compose(forms -> {
+                composeInfos.put(FORMS, forms);
+                JsonArray formIds = UtilsHelper.getIds(forms);
+                return distributionService.listByForms(formIds);
+            })
+            .onSuccess(distributions -> {
+                JsonArray respondersIds = UtilsHelper.getByProp(distributions, RESPONDER_ID);
+                composeInfos.getJsonArray(FORMS).stream().forEach(form -> notifyService.notifyNewFormFromCRON((JsonObject)form, respondersIds));
+                handler.handle(new Either.Right<>(new JsonObject()));
+            })
+            .onFailure(err -> {
+                log.error("[Formulaire@NotifyCron::launchNotifications] Failed to send notifications to forms opening today.");
+                handler.handle(new Either.Left<>(err.getMessage()));
+            });
+    }
+}

--- a/formulaire/src/main/java/fr/openent/formulaire/cron/RgpdCron.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/cron/RgpdCron.java
@@ -37,13 +37,13 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
 
     @Override
     public void handle(Long event) {
-        log.info("[Formulaire@RgpdCron] Formulaire RGPD cron started");
+        log.info("[Formulaire@RgpdCron::handle] Formulaire RGPD cron started");
         deleteOldDataForRgpd(deleteEvt -> {
             if (deleteEvt.isLeft()) {
-                log.info("[Formulaire@RgpdCron] RGPD cron failed");
+                log.error("[Formulaire@RgpdCron::handle] RGPD cron failed");
             }
             else {
-                log.info("[Formulaire@RgpdCron] RGPD cron launch successful");
+                log.info("[Formulaire@RgpdCron::handle] RGPD cron launch successful");
             }
         });
     }
@@ -51,7 +51,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
     public void deleteOldDataForRgpd(Handler<Either<String, JsonObject>> handler) {
         distributionService.deleteOldDistributions(deleteDistribsEvt -> {
             if (deleteDistribsEvt.isLeft()) {
-                log.error("[Formulaire@deleteOldDataForRgpd] An error occurred while deleting distributions for old responses");
+                log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] An error occurred while deleting distributions for old responses");
                 handler.handle(new Either.Left<>(deleteDistribsEvt.left().getValue()));
                 return;
             }
@@ -65,7 +65,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
             JsonArray deletedDistribIds = getIds(deletedDistrib);
             responseService.deleteOldResponse(deletedDistribIds, deleteResponseEvt -> {
                 if (deleteResponseEvt.isLeft()) {
-                    log.error("[Formulaire@deleteOldDataForRgpd] Failed to delete old responses for RGPD forms");
+                    log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] Failed to delete old responses for RGPD forms");
                     handler.handle(new Either.Left<>(deleteResponseEvt.left().getValue()));
                     return;
                 }
@@ -80,7 +80,7 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
                 JsonArray deletedRepIds = getIds(deleteResponseEvt.right().getValue());
                 responseFileService.deleteAllByResponse(deletedRepIds, deleteFilesEvt -> {
                     if (deleteFilesEvt.isLeft()) {
-                        log.error("[Formulaire@deleteOldDataForRgpd] An error occurred while deleting files for responses " + deletedRepIds);
+                        log.error("[Formulaire@RgpdCron::deleteOldDataForRgpd] An error occurred while deleting files for responses " + deletedRepIds);
                         handler.handle(new Either.Left<>(deleteFilesEvt.left().getValue()));
                         return;
                     }
@@ -96,6 +96,6 @@ public class RgpdCron extends ControllerHelper implements Handler<Long> {
 
     private void logDeletedDistribInfos(JsonArray deletedDistribs) {
         JsonArray distribInfos = mapByProps(deletedDistribs, new JsonArray().add(FORM_ID).add(RESPONDER_ID));
-        log.info("[Formulaire@deleteOldDataForRgpd] Distributions and response successfully deleted for : " + distribInfos);
+        log.info("[Formulaire@RgpdCron::deleteOldDataForRgpd] Distributions and response successfully deleted for : " + distribInfos);
     }
 }

--- a/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
@@ -1,6 +1,7 @@
 package fr.openent.formulaire.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -65,12 +66,18 @@ public interface DistributionService {
     void countFinished(String formId, Handler<Either<String, JsonObject>> handler);
 
     /**
-     * Get the number of distributions for a specific form
+     * Get the number of distributions with TO_DO status for a specific form
      * @param formId form identifier
      * @param user user connected
-     * @param handler function handler returning JsonObject data
      */
-    void countMyToDo(String formId, UserInfos user, Handler<Either<String, JsonObject>> handler);
+    Future<JsonObject> countMyToDo(String formId, UserInfos user);
+
+    /**
+     * Get the number of distributions with FINISHED status for a specific form
+     * @param formId form identifier
+     * @param user user connected
+     */
+    Future<JsonObject> countMyFinished(String formId, UserInfos user);
 
     /**
      * Get a specific distribution by id
@@ -90,9 +97,8 @@ public interface DistributionService {
     /**
      * Create a new distribution based on an already existing one
      * @param distribution JsonObject data
-     * @param handler function handler returning JsonObject data
      */
-    void add(JsonObject distribution, Handler<Either<String, JsonObject>> handler);
+    Future<JsonObject> add(JsonObject distribution);
 
     /**
      * Duplicate a distribution by id

--- a/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/DistributionService.java
@@ -32,6 +32,12 @@ public interface DistributionService {
     void listByForm(String formId, Handler<Either<String, JsonArray>> handler);
 
     /**
+     * List all the distributions of specific forms
+     * @param formIds form identifiers
+     */
+    Future<JsonArray> listByForms(JsonArray formIds);
+
+    /**
      * List all the distributions for a specific form sent to me
      * @param formId form identifier
      * @param user user connected

--- a/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
@@ -36,9 +36,8 @@ public interface FormService {
      * List all the forms for the linker
      * @param groupsAndUserIds list of neo ids including the connected user
      * @param user user connected
-     * @param handler function handler returning JsonArray data
      */
-    void listForLinker(List<String> groupsAndUserIds, UserInfos user, Handler<Either<String, JsonArray>> handler);
+    Future<JsonArray> listForLinker(List<String> groupsAndUserIds, UserInfos user);
 
     /**
      * List all the contributors to a form

--- a/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
@@ -1,6 +1,7 @@
 package fr.openent.formulaire.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
@@ -52,6 +53,13 @@ public interface FormService {
      * @param handler function handler returning JsonArray data
      */
     void listManagers(String formId, Handler<Either<String, JsonArray>> handler);
+
+    /**
+     * Get a specific form by id
+     * @param formId form identifier
+     * @param user user connected
+     */
+    Future<JsonObject> get(String formId, UserInfos user);
 
     /**
      * Get a specific form by id

--- a/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
@@ -54,6 +54,11 @@ public interface FormService {
     void listManagers(String formId, Handler<Either<String, JsonArray>> handler);
 
     /**
+     * List all sent forms opening today
+     */
+    Future<JsonArray> listSentFormsOpeningToday();
+
+    /**
      * Get a specific form by id
      * @param formId form identifier
      * @param user user connected

--- a/formulaire/src/main/java/fr/openent/formulaire/service/NotifyService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/NotifyService.java
@@ -7,12 +7,19 @@ import io.vertx.core.json.JsonObject;
 public interface NotifyService {
 
     /**
-     * Send notification when a nwe form is distributed to a responder
+     * Send notification when a new form is distributed to a list of responders
      * @param request request
      * @param form form sent
      * @param responders ids of the responders to the form
      */
     void notifyNewForm(HttpServerRequest request, JsonObject form, JsonArray responders);
+
+    /**
+     * Send notification to a list of responders via a CRON
+     * @param form form sent
+     * @param responders ids of the responders to the form
+     */
+    void notifyNewFormFromCRON(JsonObject form, JsonArray responders);
 
     /**
      * Send notification when a response is send by a responder

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultDistributionService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultDistributionService.java
@@ -163,13 +163,13 @@ public class DefaultDistributionService implements DistributionService {
                 .add(distribution.getString(STATUS, TO_DO))
                 .add(distribution.getString(STRUCTURE, null));
 
-        if (distribution.getString(DATE_RESPONSE, null) != null) {
-            query += ", date_response = ?";
-            params.add(distribution.getString(DATE_RESPONSE));
-        }
-        else if (distribution.getString(STATUS).equals(FINISHED)) {
+        if (distribution.getString(STATUS).equals(FINISHED)) {
             query += ", date_response = ?";
             params.add("NOW()");
+        }
+        else if (distribution.getString(DATE_RESPONSE, null) != null) {
+            query += ", date_response = ?";
+            params.add(distribution.getString(DATE_RESPONSE));
         }
 
         query += " WHERE id = ? RETURNING *;";

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
@@ -129,6 +129,21 @@ public class DefaultFormService implements FormService {
     }
 
     @Override
+    public Future<JsonArray> listSentFormsOpeningToday() {
+        Promise<JsonArray> promise = Promise.promise();
+
+        String query = "SELECT * FROM " + FORM_TABLE + " WHERE sent = ? " +
+                "AND date_opening >= TO_CHAR(NOW(),'YYYY-MM-DD')::date " +
+                "AND date_opening < TO_CHAR(NOW() + INTERVAL '1 day','YYYY-MM-DD')::date";
+        JsonArray params = new JsonArray().add(true);
+
+        String errorMessage = "[Formulaire@DefaultFormService::listFormsOpeningToday] Fail to list forms opening today";
+        Sql.getInstance().prepared(query, params, SqlResult.validResultHandler(FutureHelper.handlerEither(promise, errorMessage)));
+
+        return promise.future();
+    }
+
+    @Override
     public Future<JsonObject> get(String formId, UserInfos user) {
         Promise<JsonObject> promise = Promise.promise();
 

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultNotifyService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultNotifyService.java
@@ -46,12 +46,8 @@ public class DefaultNotifyService implements NotifyService {
                     .put(PARAM_PUSH_NOTIF, new JsonObject().put(TITLE, "push.notif.formulaire.newForm").put(BODY, ""))
                     .put(PARAM_RESOURCE_URI, formUri);
 
-            JsonObject mobileResource = new JsonObject()
-                    .put(ID, form.getInteger(ID).toString())
-                    .put(URI, formUri);
-
             timelineHelper.notifyTimeline(request, "formulaire.new_form_notification", user,
-                    responders.getList(), mobileResource.toString(), params);
+                    responders.getList(), params);
         });
     }
 
@@ -65,24 +61,19 @@ public class DefaultNotifyService implements NotifyService {
                 return;
             }
 
-            String formUri = "/formulaire#/form/" + form.getInteger(ID) + "/edit";
+            String formResultsUri = "/formulaire#/form/" + form.getInteger(ID) + "/results/1";
 
             JsonObject params = new JsonObject()
                     .put(ANONYMOUS, form.getBoolean(ANONYMOUS))
                     .put(PARAM_USER_ID, "/userbook/annuaire#" + user.getUserId())
                     .put(USERNAME, user.getUsername())
-                    .put(PARAM_FORM_URI, formUri)
+                    .put(PARAM_FORM_URI, "/formulaire#/form/" + form.getInteger(ID) + "/edit")
                     .put(PARAM_FORM_NAME, form.getString(TITLE))
-                    .put(PARAM_FORM_RESULTS_URI, "/formulaire#/form/" + form.getInteger(ID) + "/results/1")
+                    .put(PARAM_FORM_RESULTS_URI, formResultsUri)
                     .put(PARAM_PUSH_NOTIF, new JsonObject().put(TITLE, "push.notif.formulaire.response").put(BODY, ""))
-                    .put(PARAM_RESOURCE_URI, formUri);
+                    .put(PARAM_RESOURCE_URI, formResultsUri);
 
-            JsonObject mobileResource = new JsonObject()
-                    .put(ID, form.getInteger(ID).toString())
-                    .put(URI, formUri);
-
-            timelineHelper.notifyTimeline(request, "formulaire.response_notification", user,
-                    managers.getList(), mobileResource.toString(), params);
+            timelineHelper.notifyTimeline(request, "formulaire.response_notification", user, managers.getList(), params);
         });
     }
 }

--- a/formulaire/src/main/resources/i18n/timeline/en.json
+++ b/formulaire/src/main/resources/i18n/timeline/en.json
@@ -13,6 +13,7 @@
   "timeline.formulaire.lambda.sender": "A user ",
   "timeline.formulaire.responded": " has responded to the form ",
   "timeline.formulaire.sent": " has sent you a new form. ",
+  "timeline.formulaire.sent.by.unknow": "Vous avez reçu un nouveau formulaire. ",
   "timeline.formulaire.see": ". See the ",
   "timeline.formulaire.results": "results",
   "timeline.formulaire.access": "Go to the form "

--- a/formulaire/src/main/resources/i18n/timeline/fr.json
+++ b/formulaire/src/main/resources/i18n/timeline/fr.json
@@ -13,6 +13,7 @@
     "timeline.formulaire.lambda.sender": "Un utilisateur ",
     "timeline.formulaire.responded": " a répondu au formulaire ",
     "timeline.formulaire.sent": " vous a envoyé un formulaire. ",
+    "timeline.formulaire.sent.by.unknow": "Vous avez reçu un nouveau formulaire. ",
     "timeline.formulaire.see": ". Voir les ",
     "timeline.formulaire.results": "résultats",
     "timeline.formulaire.access": "Accéder au formulaire "

--- a/formulaire/src/main/resources/public/template/containers/preview-form.html
+++ b/formulaire/src/main/resources/public/template/containers/preview-form.html
@@ -59,7 +59,7 @@
             </div>
             <div class="section-main">
                 <div ng-repeat="question in vm.preview.formElement.questions.all | orderBy:'section_position'">
-                    <respond-question-item ng-if="vm.preview.formElement.question_type != Types.MATRIX"
+                    <respond-question-item ng-if="question.question_type != Types.MATRIX"
                                            question="question"
                                            response="vm.preview.elementResponses[question.section_position - 1]"
                                            distribution="null"
@@ -67,8 +67,8 @@
                                            responses-choices="vm.preview.choices"
                                            files="vm.preview.files">
                     </respond-question-item>
-                    <respond-matrix ng-if="vm.preview.formElement.question_type == Types.MATRIX"
-                                    question="vm.preview.formElement"
+                    <respond-matrix ng-if="question.question_type == Types.MATRIX"
+                                    question="question"
                                     responses="vm.preview.elementResponses[question.section_position - 1]"
                                     distribution="null">
                     </respond-matrix>

--- a/formulaire/src/main/resources/public/template/containers/preview-form.html
+++ b/formulaire/src/main/resources/public/template/containers/preview-form.html
@@ -54,7 +54,7 @@
             <div class="section-top">
                 <div class="title"><h4>[[vm.preview.formElement.title]]</h4></div>
                 <div class="description" ng-if="vm.preview.formElement.description">
-                    <div ng-bind-html="vm.preview.formElement.description"></div>
+                    <div data-ng-bind-html="vm.getHtmlDescription(vm.preview.formElement.description)"></div>
                 </div>
             </div>
             <div class="section-main">

--- a/formulaire/src/main/resources/public/template/containers/recap-questions.html
+++ b/formulaire/src/main/resources/public/template/containers/recap-questions.html
@@ -38,7 +38,7 @@
                     <div class="section-top">
                         <div class="title"><h4>[[formElement.title]]</h4></div>
                         <div class="description" ng-if="formElement.description">
-                            <div ng-bind-html="formElement.description"></div>
+                            <div data-ng-bind-html="vm.getHtmlDescription(formElement.description)"></div>
                         </div>
                     </div>
                     <div class="section-main">

--- a/formulaire/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire/src/main/resources/public/template/containers/respond-question.html
@@ -40,7 +40,7 @@
                 <div class="section-top">
                     <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                     <div class="description" ng-if="vm.formElement.description">
-                        <div ng-bind-html="vm.formElement.description"></div>
+                        <div data-ng-bind-html="vm.getHtmlDescription(vm.formElement.description)"></div>
                     </div>
                 </div>
                 <div class="section-main">

--- a/formulaire/src/main/resources/public/template/containers/results-form.html
+++ b/formulaire/src/main/resources/public/template/containers/results-form.html
@@ -31,7 +31,7 @@
             <div class="section-top">
                 <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                 <div class="description" ng-if="vm.formElement.description">
-                    <div ng-bind-html="vm.formElement.description"></div>
+                    <div data-ng-bind-html="vm.getHtmlDescription(vm.formElement.description)"></div>
                 </div>
             </div>
             <div class="section-main">

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -91,11 +91,12 @@ interface ViewModel {
     backToEditor() : void;
     prev() : void;
     next() : void;
+    getHtmlDescription(description: string) : string;
 }
 
 
-export const formEditorController = ng.controller('FormEditorController', ['$scope',
-    function ($scope) {
+export const formEditorController = ng.controller('FormEditorController', ['$scope', '$sce',
+    function ($scope, $sce) {
 
         const vm: ViewModel = this;
         vm.form = new Form();
@@ -652,6 +653,10 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             $scope.safeApply();
         };
 
+        vm.getHtmlDescription = (description: string) : string => {
+            return !!description ? $sce.trustAsHtml(description) : null;
+        }
+
         // Utils
 
         const initNestedSortables = () : void => {
@@ -815,7 +820,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
 
         const isInDontSave = (el) : boolean => {
             if (!el) { return false; }
-            else if (el.classList && el.classList.contains("dontSave")) { return true; }
+            else if (el.classList && el.classList.contains("dontSave") || el.tagName === "LIGHTBOX") { return true; }
             return isInDontSave(el.parentNode);
         };
 

--- a/formulaire/src/main/resources/public/ts/controllers/form-results.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-results.ts
@@ -39,11 +39,12 @@ interface ViewModel {
     next() : Promise<void>;
     goTo(position: number) : Promise<void>;
     getGraphQuestions() : Question[];
+    getHtmlDescription(description: string): string;
 }
 
 
-export const formResultsController = ng.controller('FormResultsController', ['$scope',
-    function ($scope) {
+export const formResultsController = ng.controller('FormResultsController', ['$scope', '$sce',
+    function ($scope, $sce) {
 
         const vm: ViewModel = this;
         vm.formElements = new FormElements();
@@ -126,6 +127,10 @@ export const formResultsController = ng.controller('FormResultsController', ['$s
         vm.getGraphQuestions = () : Question[] => {
             return vm.formElements.getAllQuestions().all.filter((q: Question) => q.isTypeGraphQuestion());
         };
+
+        vm.getHtmlDescription = (description: string) : string => {
+            return !!description ? $sce.trustAsHtml(description) : null;
+        }
 
         // Navigation
 

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -8,7 +8,9 @@ import {
     Folders,
     Form,
     Forms,
-    Question, Sections
+    Question,
+    Section,
+    Sections
 } from "../models";
 import {distributionService, formService, questionService, folderService} from "../services";
 import {FiltersFilters, FiltersOrders, FORMULAIRE_EMIT_EVENT} from "@common/core/enums";
@@ -233,15 +235,15 @@ export const formsListController = ng.controller('FormsListController', ['$scope
     };
 
     vm.shareForm = async() : Promise<void> => {
-        let questions =  Mix.castArrayAs(Question, await questionService.list(vm.forms.selected[0].id));
-        let sections = new Sections();
+        let questions: Question[] =  Mix.castArrayAs(Question, await questionService.list(vm.forms.selected[0].id));
+        let sections: Sections = new Sections();
         await sections.sync(vm.forms.selected[0].id);
 
         // Check validity of questions children of sections
-        let questionsList = sections.all.map(s => s.questions.all);
+        let questionsList: Question[][] = sections.all.map(s => s.questions.all);
         for (let questions of questionsList) {
-            let conditionalQuestions = questions.filter(q => q.conditional);
-            let wrongQuestions = questions.filter(q => !q.title);
+            let conditionalQuestions: Question[] = questions.filter(q => q.conditional);
+            let wrongQuestions: Question[] = questions.filter(q => !q.title);
 
             if (conditionalQuestions.length >= 2) {
                 notify.error(idiom.translate('formulaire.element.block.sharing.multiple.conditional'));
@@ -254,8 +256,8 @@ export const formsListController = ng.controller('FormsListController', ['$scope
         }
 
         // Check validity of main question and section
-        let wrongQuestions = questions.filter(question => !question.title);
-        let wrongSections = sections.filter(s => !s.title);
+        let wrongQuestions: Question[] = questions.filter(question => !question.title);
+        let wrongSections: Section[] = sections.filter(s => !s.title);
         if (wrongQuestions.length > 0 || wrongSections.length > 0){
             notify.error(idiom.translate('formulaire.block.sharing'));
             return;
@@ -265,20 +267,25 @@ export const formsListController = ng.controller('FormsListController', ['$scope
         template.open('lightbox', 'lightbox/form-sharing');
         vm.display.lightbox.sharing = true;
         window.setTimeout(async function () {
-            let contribs = document.querySelectorAll('[data-label="Contribuer"]');
-            let gestions = document.querySelectorAll('[data-label="Gérer"]');
+            let contribs: NodeListOf<HTMLElement> = document.querySelectorAll('[data-label="Contribuer"]');
+            let gestions: NodeListOf<HTMLElement> = document.querySelectorAll('[data-label="Gérer"]');
+            let responses: NodeListOf<HTMLElement> = document.querySelectorAll('[data-label="Répondre"]');
+
+            let ownerResponseCheck: HTMLInputElement = responses[0].children[0].children[0] as HTMLInputElement;
+            ownerResponseCheck.checked = false;
+
             for (let i = 1; i < contribs.length; i++) {
-                let contribValue = contribs[i].children[0].children[0] as HTMLInputElement;
-                let gestionValue = gestions[i].children[0].children[0] as HTMLInputElement;
+                let contribValue: HTMLInputElement = contribs[i].children[0].children[0] as HTMLInputElement;
+                let gestionValue: HTMLInputElement = gestions[i].children[0].children[0] as HTMLInputElement;
                 contribValue.addEventListener('change', (e) => {
-                    let newValue = e.target as HTMLInputElement;
+                    let newValue: HTMLInputElement = e.target as HTMLInputElement;
                     if (!newValue.checked && gestionValue.checked) {
                         gestionValue.checked = false;
                     }
                     $scope.safeApply();
                 });
                 gestionValue.addEventListener('change', (e) => {
-                    let newValue = e.target as HTMLInputElement;
+                    let newValue: HTMLInputElement = e.target as HTMLInputElement;
                     if (newValue.checked && !contribValue.checked) {
                         contribValue.checked = true;
                     }

--- a/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
@@ -9,11 +9,10 @@ import {
     Section,
     Types,
     FormElement,
-    Response, QuestionChoice
+    Response
 } from "../models";
 import {distributionService, formElementService, responseFileService, responseService} from "../services";
 import {FORMULAIRE_BROADCAST_EVENT} from "@common/core/enums";
-import {Res} from "awesome-typescript-loader/dist/checker/protocol";
 
 interface ViewModel {
     formElements: FormElements;
@@ -27,15 +26,16 @@ interface ViewModel {
         }
     };
 
-    $onInit() : Promise<void>;
-    send() : Promise<void>;
-    doSend() : Promise<void>;
-    checkMultiEtab() : boolean;
-    getStructures() : string[];
+    $onInit(): Promise<void>;
+    send(): Promise<void>;
+    doSend(): Promise<void>;
+    checkMultiEtab(): boolean;
+    getStructures(): string[];
+    getHtmlDescription(statement: string): string;
 }
 
-export const recapQuestionsController = ng.controller('RecapQuestionsController', ['$scope',
-    function ($scope) {
+export const recapQuestionsController = ng.controller('RecapQuestionsController', ['$scope', '$sce',
+    function ($scope, $sce) {
 
     const vm: ViewModel = this;
     vm.formElements = new FormElements();
@@ -122,6 +122,10 @@ export const recapQuestionsController = ng.controller('RecapQuestionsController'
     vm.getStructures = () : string[] => {
         return model.me.structureNames;
     };
+
+    vm.getHtmlDescription = (description: string) : string => {
+        return !!description ? $sce.trustAsHtml(description) : null;
+    }
 
     const checkMandatoryQuestions = async () : Promise<boolean> => {
         let mandatoryQuestions: Question[] = vm.formElements.getAllQuestions().all.filter((q: Question) => q.mandatory);

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -5,7 +5,7 @@ import {
     FormElement,
     FormElements,
     Question,
-    QuestionChoice, QuestionChoices,
+    QuestionChoice,
     Response,
     Responses,
     Section,
@@ -34,10 +34,11 @@ interface ViewModel {
     nextGuard() : void;
     saveAndQuit() : Promise<void>;
     saveAndQuitGuard() : void;
+    getHtmlDescription(description: string) : string;
 }
 
-export const respondQuestionController = ng.controller('RespondQuestionController', ['$scope',
-    function ($scope) {
+export const respondQuestionController = ng.controller('RespondQuestionController', ['$scope', '$sce',
+    function ($scope, $sce) {
 
     const vm: ViewModel = this;
     vm.formElements = new FormElements();
@@ -164,6 +165,10 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
     vm.saveAndQuitGuard = () => {
         vm.saveAndQuit().then();
     };
+
+    vm.getHtmlDescription = (description: string) : string => {
+        return !!description ? $sce.trustAsHtml(description) : null;
+    }
 
     const saveResponses = async () : Promise<boolean> => {
         let isSavingOk: boolean = false;

--- a/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-freetext.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-freetext.ts
@@ -1,12 +1,35 @@
-import {Directive, ng} from "entcore";
+import {ng} from "entcore";
 import {Question} from "@common/models";
+import {IScope} from "angular";
 
-interface IViewModel {
-    question: Question
+interface IQuestionTypeFreetextProps {
+    question: Question;
 }
 
-export const questionTypeFreetext: Directive = ng.directive('questionTypeFreetext', () => {
+interface IViewModel extends ng.IController, IQuestionTypeFreetextProps {
+    getHtmlDescription(description: string) : string;
+}
 
+interface IQuestionTypeFreetextScope extends IScope, IQuestionTypeFreetextProps {
+    vm: IViewModel;
+}
+
+class Controller implements IViewModel {
+    question: Question;
+
+    constructor(private $scope: IQuestionTypeFreetextScope, private $sce: ng.ISCEService) {}
+
+    $onInit = async (): Promise<void> => {}
+
+    $onDestroy = async (): Promise<void> => {}
+
+    getHtmlDescription = (description: string): string => {
+        return !!description ? this.$sce.trustAsHtml(description) : null;
+    }
+
+}
+
+function directive() {
     return {
         restrict: 'E',
         transclude: true,
@@ -18,7 +41,7 @@ export const questionTypeFreetext: Directive = ng.directive('questionTypeFreetex
         template: `
             <div>
                 <div ng-if="!vm.question.selected">
-                    <div ng-if="vm.question.statement" ng-bind-html="vm.question.statement"></div>
+                    <div ng-if="vm.question.statement" data-ng-bind-html="vm.getHtmlDescription(vm.question.statement)"></div>
                     <textarea disabled ng-if="!vm.question.statement" i18n-placeholder="formulaire.question.type.FREETEXT"></textarea>
                 </div>
                 <div ng-if="vm.question.selected">
@@ -26,12 +49,14 @@ export const questionTypeFreetext: Directive = ng.directive('questionTypeFreetex
                 </div>
             </div>
         `,
-
-        controller: async ($scope) => {
-            const vm: IViewModel = <IViewModel> this;
-        },
-        link: ($scope, $element) => {
-            const vm: IViewModel = $scope.vm;
+        controller: ['$scope', '$sce', Controller],
+        /* interaction DOM/element */
+        link: function ($scope: IQuestionTypeFreetextScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: IViewModel) {
         }
-    };
-});
+    }
+}
+
+export const questionTypeFreetext = ng.directive('questionTypeFreetext', directive);

--- a/formulaire/src/main/resources/sql/017-add-constraints.sql
+++ b/formulaire/src/main/resources/sql/017-add-constraints.sql
@@ -1,0 +1,13 @@
+ALTER TABLE formulaire.question
+    ADD CONSTRAINT question_unique_form_position UNIQUE (form_id, position),
+    ADD CONSTRAINT question_unique_section_position UNIQUE (section_id, section_position),
+    ADD CONSTRAINT question_unique_matrix_position UNIQUE (matrix_id, matrix_position),
+    ADD CONSTRAINT question_check_pairing
+    CHECK (
+        (section_id IS NOT NULL AND section_position IS NOT NULL AND matrix_id IS NULL AND matrix_position IS NULL AND position IS NULL) OR
+        (matrix_id IS NOT NULL AND matrix_position IS NOT NULL AND section_id IS NULL AND section_position IS NULL AND position IS NULL) OR
+        (position IS NOT NULL AND section_id IS NULL AND section_position IS NULL AND matrix_id IS NULL AND matrix_position IS NULL)
+    );
+
+ALTER TABLE formulaire.section
+    ADD CONSTRAINT section_unique_form_position UNIQUE (form_id, position);

--- a/formulaire/src/main/resources/view-src/notify/new_form_notification.html
+++ b/formulaire/src/main/resources/view-src/notify/new_form_notification.html
@@ -1,14 +1,14 @@
 <span>{{#i18n}}timeline.formulaire.new.notification{{/i18n}}</span>
-{{#userUri}}<a href="{{#host}}{{userUri}}{{/host}}">{{username}}</a>{{/userUri}}
+{{#userUri}}
+ <span>{{#i18n}}timeline.formulaire.from{{/i18n}}</span><a href="{{#host}}{{userUri}}{{/host}}">{{username}}</a>
+{{/userUri}}
 {{^userUri}}
- {{#username}}{{username}}{{/username}}
- {{^username}}<span>{{#i18n}}timeline.unknown.sender{{/i18n}}</span>{{/username}}
+ {{#username}}<span>{{#i18n}}timeline.formulaire.from{{/i18n}}</span>{{username}}{{/username}}
 {{/userUri}}
  :<br/>
 
-{{#username}}{{username}}{{/username}}
-{{^username}}<span>{{#i18n}}timeline.unknown.sender{{/i18n}}</span>{{/username}}
-<span>{{#i18n}}timeline.formulaire.sent{{/i18n}}</span>
+{{#username}}{{username}}<span>{{#i18n}}timeline.formulaire.sent{{/i18n}}</span>{{/username}}
+{{^username}}<span>{{#i18n}}timeline.formulaire.sent.by.unknow{{/i18n}}</span>{{/username}}
 {{#formUri}}
  {{#formName}}
   <span>{{#i18n}}timeline.formulaire.access{{/i18n}}</span>

--- a/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultFormServiceTest.java
+++ b/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultFormServiceTest.java
@@ -8,13 +8,19 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.entcore.common.sql.Sql;
+import org.entcore.common.user.UserInfos;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static fr.openent.form.core.constants.EbFields.FORMULAIRE_ADDRESS;
 import static fr.openent.form.core.constants.Fields.*;
-import static fr.openent.form.core.constants.Tables.FORM_TABLE;
+import static fr.openent.form.core.constants.ShareRights.MANAGER_RESOURCE_BEHAVIOUR;
+import static fr.openent.form.core.constants.Tables.*;
 
 @RunWith(VertxUnitRunner.class)
 public class DefaultFormServiceTest {
@@ -43,5 +49,71 @@ public class DefaultFormServiceTest {
             async.complete();
         });
         defaultFormService.listByIds(formIds, null);
+    }
+
+    @Test
+    public void testListForLinkerWithEmptyGroupsAndUser(TestContext ctx) {
+        Async async = ctx.async();
+        List<String> groupsAndUserIds = new ArrayList<>();
+        UserInfos user = new UserInfos();
+        user.setUserId("userId");
+
+        String expectedQuery = "SELECT f.* FROM " + FORM_TABLE + " f " +
+                "LEFT JOIN " + FORM_SHARES_TABLE + " fs ON f.id = fs.resource_id " +
+                "LEFT JOIN " + MEMBERS_TABLE + " m ON (fs.member_id = m.id AND m.group_id IS NOT NULL) " +
+                "WHERE f.archived = ? AND (f.sent = ? OR f.is_public = ?) AND (f.owner_id = ?) " +
+                "GROUP BY f.id " +
+                "ORDER BY f.date_modification DESC;";
+
+        JsonArray expectedParams = new JsonArray().add(false).add(true).add(true).add(user.getUserId());
+
+        vertx.eventBus().consumer(FORMULAIRE_ADDRESS, message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals(PREPARED, body.getString(ACTION));
+            ctx.assertEquals(expectedQuery, body.getString(STATEMENT));
+            ctx.assertEquals(expectedParams.toString(), body.getJsonArray(VALUES).toString());
+            async.complete();
+        });
+
+        defaultFormService.listForLinker(groupsAndUserIds, user)
+            .onSuccess(result -> async.complete());
+
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testListForLinkerWithGroupsAndUser(TestContext ctx) {
+        Async async = ctx.async();
+        List<String> groupsAndUserIds = new ArrayList<>();
+        groupsAndUserIds.add("groupId");
+        UserInfos user = new UserInfos();
+        user.setUserId("userId");
+
+        String expectedQuery = "SELECT f.* FROM " + FORM_TABLE + " f " +
+                "LEFT JOIN " + FORM_SHARES_TABLE + " fs ON f.id = fs.resource_id " +
+                "LEFT JOIN " + MEMBERS_TABLE + " m ON (fs.member_id = m.id AND m.group_id IS NOT NULL) " +
+                "WHERE f.archived = ? AND (f.sent = ? OR f.is_public = ?) " +
+                "AND ((fs.member_id IN " + Sql.listPrepared(groupsAndUserIds.toArray()) +" AND fs.action = ?) OR f.owner_id = ?) " +
+                "GROUP BY f.id " +
+                "ORDER BY f.date_modification DESC;";
+
+        JsonArray expectedParams = new JsonArray().add(false).add(true).add(true);
+        for (String groupOrUser : groupsAndUserIds) {
+            expectedParams.add(groupOrUser);
+        }
+        expectedParams.add(MANAGER_RESOURCE_BEHAVIOUR).add(user.getUserId());
+
+        vertx.eventBus().consumer(FORMULAIRE_ADDRESS, message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals(PREPARED, body.getString(ACTION));
+            ctx.assertEquals(expectedQuery, body.getString(STATEMENT));
+            ctx.assertEquals(expectedParams.toString(), body.getJsonArray(VALUES).toString());
+            async.complete();
+        });
+
+        defaultFormService.listForLinker(groupsAndUserIds, user)
+                .onSuccess(result -> async.complete());
+
+        async.awaitSuccess(10000);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 modowner=fr.openent
 
 # Your module version
-version=1.6.1
+version=1.6.2
 
 # The test timeout in seconds
 testtimeout=300
@@ -30,4 +30,4 @@ vertxCronTimer=2.0.0
 powerMockVersion=2.0.2
 mockitoVersion=2.+
 
-entCoreVersion=4.6.0
+entCoreVersion=4.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 modowner=fr.openent
 
 # Your module version
-version=1.6.2
+version=1.6-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "awesome-typescript-loader": "3.2.1",
     "axios": "0.16.2",
     "core-js": "2.4.1",
-    "entcore": "4.6.0",
+    "entcore": "4.7.0",
     "entcore-toolkit": "^1.0.1",
     "gulp": "3.9.1",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
## Describe your changes
When sharing forms, in some misunderstood cases the distriutions are created but the boolean prop "sent" is not updated.
It creates cases where the form is shared but has a prop saying he's not.
In those cases it was impossible to send a reminder to people who has not yet responded to the form.
Now we check this wrong case when sending the reminder and update the "sent" prop correctly if needed at the same time.

## Checklist tests

## Issue ticket number and link
FOR-487 : https://jira.support-ent.fr/browse/FOR-487

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)