### PR TITLE
fix(remind) : [#FOR-541] fix name displaying in remind pop-up

### DIFF
--- a/common/src/main/resources/ts/services/DistributionService.ts
+++ b/common/src/main/resources/ts/services/DistributionService.ts
@@ -7,7 +7,7 @@ import {Mix} from "entcore-toolkit";
 export interface DistributionService {
     list() : Promise<any>;
     listByResponder() : Promise<any>;
-    listByForm(formId: number) : Promise<any>;
+    listByForm(formId: number) : Promise<Distribution[]>;
     listByFormAndStatus(formId: number, status: string, nbLines: number) : Promise<any>;
     listByFormAndStatusAndQuestion(formId: number, status: string, questionId: number, nbLines: number) : Promise<any>
     listByFormAndResponder(formId: number) : Promise<Distribution[]>;
@@ -40,9 +40,10 @@ export const distributionService: DistributionService = {
         }
     },
 
-    async listByForm(formId: number) : Promise<any> {
+    async listByForm(formId: number) : Promise<Distribution[]> {
         try {
-            return DataUtils.getData(await http.get(`/formulaire/distributions/forms/${formId}/list`));
+            let data: any = DataUtils.getData(await http.get(`/formulaire/distributions/forms/${formId}/list`));
+            return Mix.castArrayAs(Distribution, data);
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.distributionService.list'));
             throw err;

--- a/common/src/main/resources/ts/utils/utils.ts
+++ b/common/src/main/resources/ts/utils/utils.ts
@@ -19,4 +19,32 @@ export class UtilsUtils {
         let randomIndex: number = Math.floor(Math.random() * list.length);
         return !(<any>excludedValues).includes(list[randomIndex]) ? list[randomIndex] : UtilsUtils.getRandomValueInList(list, excludedValues);
     }
+
+    /**
+     * Separate name and surname from a formatted full name
+     * @param fullName full name formatted like 'NAME Surname'
+     */
+    static getNameAndSurname = (fullName: string) : string[] => {
+        if (fullName == null || fullName.length == 0) return ["", ""];
+
+        let lastTimeUppercaseTwice: number = -1;
+        let previousLetter: string = fullName[0];
+        for (let i: number = 1; i < fullName.length; i++) {
+            let currentLetter: string = fullName[i];
+            if (previousLetter.toLowerCase() != previousLetter.toUpperCase() &&
+                previousLetter.toUpperCase() === previousLetter &&
+                currentLetter.toLowerCase() != currentLetter.toUpperCase() &&
+                currentLetter.toUpperCase() === currentLetter) {
+                lastTimeUppercaseTwice = i;
+            }
+            previousLetter = fullName[i];
+        }
+
+        if (lastTimeUppercaseTwice < 0) return ["", ""];
+        else {
+            let name: string = fullName.substring(0, lastTimeUppercaseTwice + 1);
+            let surname: string = fullName.substring(lastTimeUppercaseTwice + 2);
+            return [name, surname];
+        }
+    }
 }


### PR DESCRIPTION
## Describe your changes
In the remind pop-up names and surnames are displayed in two different columns.
For people with more than one word names or surnames, the displayed information was incorrect, which is now fixed.

## Checklist tests

## Issue ticket number and link
FOR-541 : https://jira.support-ent.fr/browse/FOR-541

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)