### PR TITLE
fix(colors) : [#FOR-538] fix colors displaying for great number of choices

### DIFF
--- a/common/src/main/resources/ts/core/constants/constants.ts
+++ b/common/src/main/resources/ts/core/constants/constants.ts
@@ -7,4 +7,6 @@ export abstract class Constants {
     static readonly YELLOW_COLORS: string[] = ['#FFC73C','#F2AE00','#FFBB13','#FFD263','#FFDF91'];
     static readonly PURPLE_COLORS: string[] = ['#475DD5','#1129A6','#2741C9','#687BE0','#93A1EC'];
     static readonly ORANGE_COLORS: string[] = ['#FFA23C','#F27E00','#FF8E13','#FFB463','#FFCA91'];
+    static readonly COLORS_GROUPS: Array<string[]> = [Constants.BLUE_COLORS, Constants.YELLOW_COLORS, Constants.PURPLE_COLORS, Constants.ORANGE_COLORS];
+    static readonly NB_COLORS_AVAILABLE: number = 25;
 }

--- a/common/src/main/resources/ts/utils/color.ts
+++ b/common/src/main/resources/ts/utils/color.ts
@@ -15,21 +15,21 @@ export class ColorUtils {
      * @param color String to test
      */
     static isRgbColor = (color: string) : boolean => {
-        let isRgbFormat = /rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/.test(color);
+        let isRgbFormat: boolean = /rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/.test(color);
         if (isRgbFormat) {
-            let rgbValues = color.match(/\d+/g).map(Number);
+            let rgbValues: number[] = color.match(/\d+/g).map(Number);
             if (rgbValues.length < 3 ||rgbValues.length > 4) {
                 return false;
             }
             else {
-                for (let i = 0; i < 3; i++) {
-                    let value = rgbValues[i];
+                for (let i: number = 0; i < 3; i++) {
+                    let value: number = rgbValues[i];
                     if (value < 0 || value > 255) {
                         return false;
                     }
                 }
                 if (rgbValues.length === 4) {
-                    let value = rgbValues[3];
+                    let value: number = rgbValues[3];
                     if (value < 0 || value > 1) {
                         return false;
                     }
@@ -49,10 +49,10 @@ export class ColorUtils {
             return color;
         }
         else if (ColorUtils.isRgbColor(color)) {
-            let rgbValues = color.match(/\d+/g).map(Number);
+            let rgbValues: number[] = color.match(/\d+/g).map(Number);
             // Convert each element to a base16 string and add zero if we get only one character
-            let hexColor = rgbValues.map(x => {
-                let x16 = x.toString(16);
+            let hexColor: string[] = rgbValues.map((rgbColor: number) => {
+                let x16: string = rgbColor.toString(16);
                 return x16.length === 1 ? "0" + x16 : x16;
             });
             return "#" + hexColor.join("");
@@ -69,8 +69,8 @@ export class ColorUtils {
             return color;
         }
         else if (ColorUtils.isHexaColor(color)) {
-            let hexValues = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
-            let rgbColor = hexValues ? [
+            let hexValues: RegExpExecArray = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
+            let rgbColor: number[] = hexValues ? [
                 parseInt(hexValues[1], 16),
                 parseInt(hexValues[2], 16),
                 parseInt(hexValues[3], 16)
@@ -85,7 +85,7 @@ export class ColorUtils {
      * @param color String RGB color
      */
     static getRgbValues = (color: string) : number[] => {
-        let rgbColor = ColorUtils.hexaToRgb(color);
+        let rgbColor: string = ColorUtils.hexaToRgb(color);
         return rgbColor.match(/\d+/g).map(Number);
     }
 
@@ -97,16 +97,15 @@ export class ColorUtils {
      */
     static interpolateColor = (paletteColors: string[], factor: number = 0.5) : number[] => {
         factor = factor < 0 ? 0 : (factor > 1 ? 1 : factor);
-        let colorValues = [];
 
-        let positionOnGradient = (paletteColors.length - 1) * factor;
-        let lowerValue = factor === 1 ? positionOnGradient - 1 : Math.floor(positionOnGradient);
-        let upperValue = factor === 0 ? positionOnGradient + 1 : Math.ceil(positionOnGradient);
-        let color1Values = ColorUtils.getRgbValues(paletteColors[lowerValue]);
-        let color2Values = ColorUtils.getRgbValues(paletteColors[upperValue]);
-        let newFactor = positionOnGradient / upperValue;
-        let result = [];
-        for (let i = 0; i < color1Values.length; i++) {
+        let positionOnGradient: number = (paletteColors.length - 1) * factor;
+        let lowerValue: number = factor === 1 ? positionOnGradient - 1 : Math.floor(positionOnGradient);
+        let upperValue: number = factor === 0 ? positionOnGradient + 1 : Math.ceil(positionOnGradient);
+        let color1Values: number[] = ColorUtils.getRgbValues(paletteColors[lowerValue]);
+        let color2Values: number[] = ColorUtils.getRgbValues(paletteColors[upperValue]);
+        let newFactor: number = positionOnGradient / upperValue;
+        let result: number[] = [];
+        for (let i: number = 0; i < color1Values.length; i++) {
             result.push(Math.round(color1Values[i] + (color2Values[i] - color1Values[i]) * newFactor));
         }
         return result;
@@ -122,12 +121,12 @@ export class ColorUtils {
             return ["rgb(" + ColorUtils.interpolateColor(paletteColors).join(",") + ")"];
         }
         else {
-            let stepFactor = 1 / (nbColors - 1 > 0 ? nbColors - 1 : 1);
-            let interpolatedColorArray = [];
+            let stepFactor: number = 1 / (nbColors - 1 > 0 ? nbColors - 1 : 1);
+            let interpolatedColorArray: string[] = [];
 
-            for (let i = 0; i < nbColors; i++) {
-                let rgbValues = ColorUtils.interpolateColor(paletteColors, stepFactor * i);
-                let rgbString = "rgb(" + rgbValues.join(",") + ")";
+            for (let i: number = 0; i < nbColors; i++) {
+                let rgbValues: number[] = ColorUtils.interpolateColor(paletteColors, stepFactor * i);
+                let rgbString: string = "rgb(" + rgbValues.join(",") + ")";
                 interpolatedColorArray.push(ColorUtils.rgbToHexa(rgbString));
             }
 
@@ -140,15 +139,17 @@ export class ColorUtils {
      * @param nbColors Number of colors we want to pick
      */
     static generateColorList = (nbColors: number) : string[] => {
-        let colorsGroups: Array<string[]> = [Constants.BLUE_COLORS, Constants.YELLOW_COLORS, Constants.PURPLE_COLORS, Constants.ORANGE_COLORS];
         let colorsToDisplay: string[] = [Constants.BLUE_COLORS[Math.floor(Math.random() * Constants.BLUE_COLORS.length)]];
+        let colorsToExclude: string[] = [colorsToDisplay[0]];
         let lastUsedGroup: string[] = Constants.BLUE_COLORS;
 
         while (colorsToDisplay.length < nbColors) {
-            let newColorGroup: string[] = UtilsUtils.getRandomValueInList(colorsGroups, [lastUsedGroup]);
-            let newColor: string = UtilsUtils.getRandomValueInList(newColorGroup, colorsToDisplay);
+            let newColorGroup: string[] = UtilsUtils.getRandomValueInList(Constants.COLORS_GROUPS, [lastUsedGroup]);
+            let newColor: string = UtilsUtils.getRandomValueInList(newColorGroup, colorsToExclude);
 
             colorsToDisplay.push(newColor);
+            colorsToExclude.push(newColor);
+            if (colorsToExclude.length == Constants.NB_COLORS_AVAILABLE) colorsToExclude = [];
             lastUsedGroup = newColorGroup;
         }
 

--- a/common/src/main/resources/ts/utils/utils.ts
+++ b/common/src/main/resources/ts/utils/utils.ts
@@ -16,8 +16,12 @@ export class UtilsUtils {
      * @param excludedValues    List of values to exclude from the random picking (should be same type as 'list')
      */
     static getRandomValueInList = (list: any[], excludedValues: any[]) : any => {
+        if (list.every((item: any) => (<any>excludedValues).includes(item))) {
+            return UtilsUtils.getRandomValueInList(list, []);
+        }
         let randomIndex: number = Math.floor(Math.random() * list.length);
-        return !(<any>excludedValues).includes(list[randomIndex]) ? list[randomIndex] : UtilsUtils.getRandomValueInList(list, excludedValues);
+        let randomColor: string = list[randomIndex];
+        return !(<any>excludedValues).includes(randomColor) ? randomColor : UtilsUtils.getRandomValueInList(list, excludedValues);
     }
 
     /**


### PR DESCRIPTION
## Describe your changes
When using many choices for QCM for instance, the colors number was limited to 25. Now if you reach this number we empty the pool of colors and allow the reusing of the same colors for the same graph

## Checklist tests

## Issue ticket number and link
FOR-538 : https://jira.support-ent.fr/browse/FOR-538

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)