### PR TITLE
feat(response): [#FOR-513] allow to reset response for some question types

### DIFF
--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -173,7 +173,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 				else if (question.question_type === Types.CURSOR) {
 					questionResponses.all.push(new Response(question.id, null, question.cursor_min_val));
 				}
-				if (question.isRanking()) {
+				else if (question.isRanking()) {
 					let questionChoices: QuestionChoice[] = question.choices.all;
 						for (let i: number = 0; i < questionChoices.length; i++) {
 							let questionChoice: QuestionChoice = questionChoices[i];

--- a/formulaire-public/src/main/resources/public/ts/directives/public-matrix.ts
+++ b/formulaire-public/src/main/resources/public/ts/directives/public-matrix.ts
@@ -15,6 +15,7 @@ interface IPublicMatrixProps {
 interface IViewModel extends ng.IController, IPublicMatrixProps {
     init(): Promise<void>;
     switchValue(child: Question, choice: QuestionChoice): void;
+    resetLine(child: Question): void;
 }
 
 interface IPublicQuestionItemScope extends IScope, IPublicMatrixProps {
@@ -66,6 +67,12 @@ class Controller implements IViewModel {
         }
         this.$scope.$apply();
     }
+
+    resetLine = (child: Question) : void => {
+        this.responses.all
+            .filter((r: Response) => r.question_id == child.id)
+            .forEach((r: Response) => r.selected = false);
+    }
 }
 
 
@@ -90,6 +97,7 @@ function directive() {
                             <tr>
                                 <th class="two"></th>
                                 <th ng-repeat="choice in vm.question.choices.all | orderBy:['position', 'id']">[[choice.value]]</th>
+                                <th class="one"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -101,6 +109,7 @@ function directive() {
                                                ng-model="vm.responses.all[vm.mapChildChoicesResponseIndex.get(child).get(choice)].selected">
                                     </label>
                                 </td>
+                                <td><i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.resetLine(child)"></i></td>
                             </tr>
                         </tbody>
                     </table>

--- a/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
+++ b/formulaire-public/src/main/resources/public/ts/directives/public-question-item.ts
@@ -23,6 +23,8 @@ interface IViewModel extends ng.IController, IPublicQuestionItemProps {
     moveResponse(resp: Response, direction: string): void;
     isSelectedChoiceCustom(choiceId: number): boolean;
     deselectIfEmpty(choice: QuestionChoice) : void;
+    onClickChoice(choice: QuestionChoice): void;
+    resetDate(): void;
 }
 
 interface IPublicQuestionItemScope extends IScope, IPublicQuestionItemProps {
@@ -97,6 +99,14 @@ class Controller implements IViewModel {
         }
         else return;
     }
+
+    onClickChoice = (choice: QuestionChoice) : void => {
+        this.responses.all[0].choice_id = (this.responses.all[0].choice_id != choice.id) ? choice.id : null;
+    }
+
+    resetDate = () : void => {
+        this.responses.all[0].answer = new Date();
+    }
 }
 
 function directive() {
@@ -149,14 +159,17 @@ function directive() {
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.DATE">
                         <date-picker ng-model="vm.responses.all[0].answer" input-guard></date-picker>
+                        <i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.resetDate()"></i>
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.TIME">
                         <input type="time" ng-model="vm.responses.all[0].answer" input-guard/>
+                        <i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.responses.all[0].answer = null;"></i>
                     </div>
                     <div ng-if ="vm.question.question_type == vm.Types.SINGLEANSWERRADIO">
                         <div ng-repeat ="choice in vm.question.choices.all | orderBy:['position', 'id']">
                             <label>
-                                <input type="radio" ng-model="vm.responses.all[0].choice_id" ng-value="choice.id" input-guard>
+                                <input type="radio" ng-model="vm.responses.all[0].choice_id" ng-value="choice.id"
+                                       ng-click="vm.onClickChoice(choice)" input-guard>
                                 <span>[[choice.value]]</span>
                                 <span ng-if="choice.is_custom"> : 
                                     <input type="text" ng-model="vm.responses.all[0].custom_answer"

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseController.java
@@ -229,16 +229,13 @@ public class ResponseController extends ControllerHelper {
                         });
                     }
                     else {
-                        if (question.getQuestionType() == QuestionTypes.DATE.getCode()) {
+                        if (question.getQuestionType() == QuestionTypes.DATE.getCode() && response.getString(ANSWER) != null && !response.getString(ANSWER).isEmpty()) {
                             try { dateFormatter.parse(response.getString(ANSWER)); }
                             catch (ParseException e) { e.printStackTrace(); }
                         }
-                        if (question.getQuestionType() == QuestionTypes.TIME.getCode()) {
+                        if (question.getQuestionType() == QuestionTypes.TIME.getCode() && response.getString(ANSWER) != null && !response.getString(ANSWER).isEmpty()) {
                             try { timeFormatter.parse(response.getString(ANSWER)); }
                             catch (ParseException e) { e.printStackTrace(); }
-                        }
-                        if (question.getQuestionType() == QuestionTypes.CURSOR.getCode()) {
-                            response.getString(ANSWER);
                         }
                         createResponse(request, response, user, questionId);
                     }
@@ -371,17 +368,13 @@ public class ResponseController extends ControllerHelper {
                         });
                     }
                     else {
-                        if (question_type == QuestionTypes.DATE.getCode()) {
+                        if (question_type == QuestionTypes.DATE.getCode() && response.getString(ANSWER) != null && !response.getString(ANSWER).isEmpty()) {
                             try { dateFormatter.parse(response.getString(ANSWER)); }
                             catch (ParseException e) { e.printStackTrace(); }
                         }
-                        if (question_type == QuestionTypes.TIME.getCode()) {
+                        if (question_type == QuestionTypes.TIME.getCode() && response.getString(ANSWER) != null && !response.getString(ANSWER).isEmpty()) {
                             try { timeFormatter.parse(response.getString(ANSWER)); }
                             catch (ParseException e) { e.printStackTrace(); }
-                        }
-                        if (question_type == QuestionTypes.CURSOR.getCode()) {
-                            try { response.getString(ANSWER); }
-                            catch (Exception e) { e.printStackTrace(); }
                         }
                         responseService.update(user, responseId, response, defaultResponseHandler(request));
                     }

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -93,7 +93,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
             else if (question.question_type === Types.CURSOR) {
                 questionResponses.all.push(new Response(question.id, null, question.cursor_min_val, vm.distribution.id));
             }
-            if (question.isRanking()) {
+            else if (question.isRanking()) {
                 let questionChoices: QuestionChoice[] = question.choices.all;
                 for (let i: number = 0; i < questionChoices.length; i++) {
                     let questionChoice: QuestionChoice = questionChoices[i];
@@ -240,14 +240,15 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
                     await responseService.create(new Response(child.id, null, null, vm.distribution.id));
                 }
             }
-            // In case of question type ranking, we need to add a choice index to each Response
-            if (question.isRanking()) {
+            else if (question.isRanking()) { // In case of question type ranking, we need to add a choice index to each Response
+                let promises: any = [];
                 for (let resp of responses.all) {
-                    responseService.create(new Response(question.id, resp.choice_id, resp.answer, vm.distribution.id,  resp.choice_position));
+                    promises.push(responseService.create(new Response(question.id, resp.choice_id, resp.answer, vm.distribution.id,  resp.choice_position)));
                 }
+                await Promise.all(promises);
             }
             else {
-                responseService.create(new Response(question.id, null, null, vm.distribution.id));
+                await responseService.create(new Response(question.id, null, null, vm.distribution.id));
             }
             return true;
         }

--- a/formulaire/src/main/resources/public/ts/directives/question/respond-matrix.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/respond-matrix.ts
@@ -19,6 +19,7 @@ interface IViewModel {
     $onInit(): Promise<void>;
     $onChanges(changes: any): Promise<void>;
     switchValue(child: Question, choice: QuestionChoice): void;
+    resetLine(child: Question): void;
 }
 
 export const respondMatrix: Directive = ng.directive('respondMatrix', () => {
@@ -43,6 +44,7 @@ export const respondMatrix: Directive = ng.directive('respondMatrix', () => {
                             <tr>
                                 <th class="two"></th>
                                 <th ng-repeat="choice in vm.question.choices.all | orderBy:['position', 'id']">[[choice.value]]</th>
+                                <th class="one"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -54,6 +56,7 @@ export const respondMatrix: Directive = ng.directive('respondMatrix', () => {
                                                ng-model="vm.responses.all[vm.mapChildChoicesResponseIndex.get(child).get(choice)].selected">
                                     </label>
                                 </td>
+                                <td><i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.resetLine(child)"></i></td>
                             </tr>
                         </tbody>
                     </table>
@@ -116,7 +119,12 @@ export const respondMatrix: Directive = ng.directive('respondMatrix', () => {
                         }
                     }
                 }
-                $scope.$apply();
+            }
+
+            vm.resetLine = (child: Question) : void => {
+                vm.responses.all
+                    .filter((r: Response) => r.question_id == child.id)
+                    .forEach((r: Response) => r.selected = false);
             }
         }
     };

--- a/formulaire/src/main/resources/public/ts/directives/question/respond-question-item.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/respond-question-item.ts
@@ -28,6 +28,8 @@ interface IViewModel {
     $onChanges(changes: any): Promise<void>;
     isSelectedChoiceCustom(choiceId: number): boolean;
     deselectIfEmpty(choice: QuestionChoice) : void;
+    onClickChoice(choice: QuestionChoice): void;
+    resetDate(): void;
 }
 
 export const respondQuestionItem: Directive = ng.directive('respondQuestionItem', ['$sce', ($sce) => {
@@ -82,9 +84,11 @@ export const respondQuestionItem: Directive = ng.directive('respondQuestionItem'
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.DATE">
                         <date-picker ng-model="vm.responses.all[0].answer" input-guard></date-picker>
+                        <i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.resetDate()"></i>
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.TIME">
                         <input type="time" ng-model="vm.responses.all[0].answer" input-guard/>
+                        <i class="i-restore md-icon dark-grey spaced-left" ng-click="vm.responses.all[0].answer = null;"></i>
                     </div>
                     <div ng-if="vm.question.question_type == vm.Types.FILE">
                         <formulaire-picker-file files="vm.files" multiple="true" input-guard></formulaire-picker-file>
@@ -92,7 +96,8 @@ export const respondQuestionItem: Directive = ng.directive('respondQuestionItem'
                     <div ng-if ="vm.question.question_type == vm.Types.SINGLEANSWERRADIO">
                         <div ng-repeat ="choice in vm.question.choices.all | orderBy:['position', 'id']">
                             <label>
-                                <input type="radio" ng-model="vm.responses.all[0].choice_id" ng-value="[[choice.id]]" input-guard>
+                                <input type="radio" ng-model="vm.responses.all[0].choice_id" ng-value="[[choice.id]]"
+                                       ng-click="vm.onClickChoice(choice)" input-guard>
                                 <span>[[choice.value]]</span>
                                 <span ng-if="choice.is_custom"> : 
                                     <input type="text" ng-model="vm.responses.all[0].custom_answer"
@@ -262,12 +267,19 @@ export const respondQuestionItem: Directive = ng.directive('respondQuestionItem'
                 }
                 else return;
             }
-            vm.Direction = Direction;
 
             vm.moveResponse = (resp: Response, direction: string) : void => {
                 FormElementUtils.switchPositions(vm.responses, resp.choice_position - 1, direction, PropPosition.CHOICE_POSITION);
                 vm.responses.all.sort((a: Response, b: Response) => a.choice_position - b.choice_position);
-            };
+            }
+
+            vm.onClickChoice = (choice: QuestionChoice) : void => {
+                vm.responses.all[0].choice_id = (vm.responses.all[0].choice_id != choice.id) ? choice.id : null;
+            }
+
+            vm.resetDate = () : void => {
+                vm.responses.all[0].answer = new Date();
+            }
         }
     };
 }]);


### PR DESCRIPTION
## Describe your changes
For some types of question we added the possibility for the user to reset his response. It affects :
- Type DATE
- Type HOUR
- Type SINGLEANSWERRADIO
- Type MATRIX

La liste vm.responses.all n'est jamais vide dans ce composant, c'est pour ça qu'on utilise parfois des vm.responses.all[0] sans vérification préalable

## Checklist tests

## Issue ticket number and link
FOR-513 : https://jira.support-ent.fr/browse/FOR-513

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)