### PR TITLE
fix(graph): [#FOR-564] fix calcul nb responses per choice for graph with choices

### DIFF
--- a/common/src/main/resources/ts/models/FormElement/Question.ts
+++ b/common/src/main/resources/ts/models/FormElement/Question.ts
@@ -81,7 +81,8 @@ export class Question extends FormElement {
         }
 
         // Count responses for each choice
-        results = results.filter((r: Response) => r.question_id === this.id);
+        let finishedDistribIds : number[] = distribs.all.map((d: Distribution) => d.id);
+        results = results.filter((r: Response) => r.question_id === this.id && (<any>finishedDistribIds).includes(r.distribution_id));
         for (let result of results) {
             for (let choice of this.choices.all) {
                 if (result.choice_id === choice.id) {
@@ -91,7 +92,6 @@ export class Question extends FormElement {
         }
 
         // Deal with no choice responses
-        let finishedDistribIds : number[] = distribs.all.map((d: Distribution) => d.id);
         let noResponseChoice: QuestionChoice = new QuestionChoice(this.id, this.choices.all.length + 1);
         noResponseChoice.value = idiom.translate('formulaire.response.empty');
         noResponseChoice.nbResponses = results.filter(r => !r.choice_id && (<any>finishedDistribIds).includes(r.distribution_id)).length;


### PR DESCRIPTION
## Describe your changes
Improve calculation of number of responses per choice for graph of questions with choices (unfinished responses were wrongly counted in PDF export)

## Checklist tests

## Issue ticket number and link
FOR-564 : https://jira.support-ent.fr/browse/FOR-564

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)