### PR TITLE
feat(graph): #FOR-584 force whole number in xasis

### DIFF
--- a/common/src/main/resources/ts/utils/graph.ts
+++ b/common/src/main/resources/ts/utils/graph.ts
@@ -445,8 +445,7 @@ export class GraphUtils {
                     labels: {
                         formatter: function (val) {
                             return val === Math.round(val) ? val.toFixed() : null;
-                        },
-                        showDuplicates: false,
+                        }
                     },
                     title: {
                         text: lang.translate('formulaire.number.responses'),

--- a/common/src/main/resources/ts/utils/graph.ts
+++ b/common/src/main/resources/ts/utils/graph.ts
@@ -442,6 +442,12 @@ export class GraphUtils {
                 },
                 xaxis: {
                     categories: labels,
+                    labels: {
+                        formatter: function (val) {
+                            return val === Math.round(val) ? val.toFixed() : null;
+                        },
+                        showDuplicates: false,
+                    },
                     title: {
                         text: lang.translate('formulaire.number.responses'),
                         style: {

--- a/formulaire/src/main/resources/public/ts/directives/question/result-question-item/result-question-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/question/result-question-item/result-question-item.html
@@ -105,8 +105,8 @@
     </div>
 
     <!-- Graph for CURSOR -->
-    <div class="graph-histogram twelve" ng-if="vm.question.question_type == vm.Types.CURSOR">
-        <div class="eight" style="height: 400px">
+    <div class="graph-histogram-cursor twelve" ng-if="vm.question.question_type == vm.Types.CURSOR">
+        <div class="eight margin-auto" style="height: 400px">
             <div id="chart-[[vm.question.id]]"></div>
         </div>
         <div>


### PR DESCRIPTION
## Describe your changes
Added condition in graph's option to prevent weird decimal number in case of small number of result, like only one vote per choice who display 0, 0.3, 0.7 insteed of 0 - 1 - 2. There is not perfect fix for that for the moment in apexchart, so I had to do this trick, but you should know that you have to manage duplicate because if you simply want to troncate your number, because you have 0.3 & 0.7, you will have 1 & 1 insteed.

## Checklist tests

## Issue ticket number and link
[FOR-584](https://jira.support-ent.fr/browse/FOR-584)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)