### PR TITLE
fix(graph): [#FOR-582] round average value in export PDF

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/export/FormResponsesExportPDF.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/export/FormResponsesExportPDF.java
@@ -239,7 +239,8 @@ public class FormResponsesExportPDF {
                     if (question.getJsonObject(QUESTION_TYPE).getBoolean(IS_CURSOR)) {
                         question.put(NB_RESPONSES, question.getInteger(NB_RESPONSES, 0) + 1);
                         question.put(SUM_RESPONSES, question.getDouble(SUM_RESPONSES, 0d) + Double.parseDouble(response.getString(ANSWER)));
-                        question.put(CURSOR_AVERAGE, question.getDouble(SUM_RESPONSES, 0d) / question.getInteger(NB_RESPONSES, 1));
+                        Double newAverage = question.getDouble(SUM_RESPONSES, 0d) / question.getInteger(NB_RESPONSES, 1);
+                        question.put(CURSOR_AVERAGE, (double)Math.round(newAverage * 100d) / 100d);
                     }
                     if (!question.getBoolean(HAS_CUSTOM_ANSWERS) && response.getString(CUSTOM_ANSWER) != null) {
                         question.put(HAS_CUSTOM_ANSWERS, true);


### PR DESCRIPTION
## Describe your changes
In front view, cursor average responses was rounded to 2 decimals. We did the same in export PDF.

## Checklist tests
- Export a PDF where the average is a double with many decimals (ex : 6.3333333333)

## Issue ticket number and link
FOR-582 : https://jira.support-ent.fr/browse/FOR-582

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)