### PR TITLE
fix(DnD): [#FOR-531] fix targetting system on drag and drop

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/Fields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/Fields.java
@@ -9,6 +9,7 @@ public class Fields {
     public static final String ANONYMOUS = "anonymous";
     public static final String ANSWER = "answer";
     public static final String ARCHIVED = "archived";
+    public static final String ALL = "all";
     public static final String ARR = "arr";
     public static final String CAPTCHA_ID = "captcha_id";
     public static final String CHOICE_ID = "choice_id";

--- a/common/src/main/java/fr/openent/form/core/models/Form.java
+++ b/common/src/main/java/fr/openent/form/core/models/Form.java
@@ -68,6 +68,9 @@ public class Form implements Model<Form> {
         else if (form.getValue(FORM_ELEMENTS, null) instanceof JsonObject && form.getJsonObject(FORM_ELEMENTS, null).containsKey(ARR)) {
             this.formElements = FormElement.toListFormElements(form.getJsonObject(FORM_ELEMENTS, null).getJsonArray(ARR));
         }
+        else if (form.getValue(FORM_ELEMENTS, null) instanceof JsonObject && form.getJsonObject(FORM_ELEMENTS, null).containsKey(ALL)) {
+            this.formElements = FormElement.toListFormElements(form.getJsonObject(FORM_ELEMENTS, null).getJsonArray(ALL));
+        }
     }
 
 

--- a/common/src/main/java/fr/openent/form/core/models/Question.java
+++ b/common/src/main/java/fr/openent/form/core/models/Question.java
@@ -17,7 +17,7 @@ public class Question extends FormElement implements Model<Question> {
     private String placeholder;
     private Number matrixId;
     private Number matrixPosition;
-    private List<QuestionChoice> questionChoices;
+    private List<QuestionChoice> choices;
     private List<Question> children;
 
 
@@ -39,11 +39,14 @@ public class Question extends FormElement implements Model<Question> {
         this.matrixId = question.getNumber(MATRIX_ID,null);
         this.matrixPosition = question.getNumber(MATRIX_POSITION,null);
 
-        if (question.getValue(QUESTION_CHOICES, null) instanceof JsonArray) {
-            this.questionChoices = new QuestionChoice().toList(question.getJsonArray(QUESTION_CHOICES, null));
+        if (question.getValue(CHOICES, null) instanceof JsonArray) {
+            this.choices = new QuestionChoice().toList(question.getJsonArray(CHOICES, null));
         }
-        else if (question.getValue(QUESTION_CHOICES, null) instanceof JsonObject && question.getJsonObject(QUESTION_CHOICES, null).containsKey(ARR)) {
-            this.questionChoices = new QuestionChoice().toList(question.getJsonObject(QUESTION_CHOICES, null).getJsonArray(ARR));
+        else if (question.getValue(CHOICES, null) instanceof JsonObject && question.getJsonObject(CHOICES, null).containsKey(ARR)) {
+            this.choices = new QuestionChoice().toList(question.getJsonObject(CHOICES, null).getJsonArray(ARR));
+        }
+        else if (question.getValue(CHOICES, null) instanceof JsonObject && question.getJsonObject(CHOICES, null).containsKey(ALL)) {
+            this.choices = new QuestionChoice().toList(question.getJsonObject(CHOICES, null).getJsonArray(ALL));
         }
 
         if (question.getValue(CHILDREN, null) instanceof JsonArray) {
@@ -51,6 +54,9 @@ public class Question extends FormElement implements Model<Question> {
         }
         else if (question.getValue(CHILDREN, null) instanceof JsonObject && question.getJsonObject(CHILDREN, null).containsKey(ARR)) {
             this.children = new Question().toList(question.getJsonObject(CHILDREN, null).getJsonArray(ARR));
+        }
+        else if (question.getValue(CHILDREN, null) instanceof JsonObject && question.getJsonObject(CHILDREN, null).containsKey(ALL)) {
+            this.children = new Question().toList(question.getJsonObject(CHILDREN, null).getJsonArray(ALL));
         }
     }
 
@@ -77,7 +83,7 @@ public class Question extends FormElement implements Model<Question> {
 
     public Number getMatrixPosition() { return matrixPosition; }
 
-    public List<QuestionChoice> getQuestionChoices() { return questionChoices; }
+    public List<QuestionChoice> getChoices() { return choices; }
 
     public List<Question> getChildren() { return children; }
 
@@ -134,8 +140,8 @@ public class Question extends FormElement implements Model<Question> {
         return this;
     }
 
-    public Question setQuestionChoices(List<QuestionChoice> questionChoices) {
-        this.questionChoices = questionChoices;
+    public Question setChoices(List<QuestionChoice> choices) {
+        this.choices = choices;
         return this;
     }
 
@@ -164,7 +170,7 @@ public class Question extends FormElement implements Model<Question> {
                 .put(PLACEHOLDER, this.placeholder)
                 .put(MATRIX_ID, this.matrixId)
                 .put(MATRIX_POSITION, this.matrixPosition)
-                .put(QUESTION_CHOICES, new QuestionChoice().toJsonArray(this.questionChoices))
+                .put(CHOICES, new QuestionChoice().toJsonArray(this.choices))
                 .put(CHILDREN, new Question().toJsonArray(this.children));
     }
 

--- a/common/src/main/java/fr/openent/form/core/models/Section.java
+++ b/common/src/main/java/fr/openent/form/core/models/Section.java
@@ -36,6 +36,9 @@ public class Section extends FormElement implements Model<Section> {
         else if (section.getValue(QUESTIONS, null) instanceof JsonObject && section.getJsonObject(QUESTIONS, null).containsKey(ARR)) {
             this.questions = new Question().toList(section.getJsonObject(QUESTIONS, null).getJsonArray(ARR));
         }
+        else if (section.getValue(QUESTIONS, null) instanceof JsonObject && section.getJsonObject(QUESTIONS, null).containsKey(ALL)) {
+            this.questions = new Question().toList(section.getJsonObject(QUESTIONS, null).getJsonArray(ALL));
+        }
     }
 
 

--- a/common/src/main/resources/ts/models/FormElement/FormElement.ts
+++ b/common/src/main/resources/ts/models/FormElement/FormElement.ts
@@ -49,7 +49,7 @@ export abstract class FormElement implements Selectable {
     }
 
     equals = (formElement: FormElement) : boolean => {
-        return this.form_element_type === formElement.form_element_type && this.id === formElement.id;
+        return formElement && this.form_element_type === formElement.form_element_type && this.id === formElement.id;
     }
 
     getPosition = (formElements: FormElements) : number => {
@@ -61,15 +61,14 @@ export abstract class FormElement implements Selectable {
     getFollowingFormElement = (formElements: FormElements) : FormElement => {
         // Case formElement is not formElement but question inside a section
         if (this instanceof Question && this.section_id) {
-            let parent: Section = this.getParentSection(formElements);
-            let nextElements: FormElement[] = formElements.all.filter((e: FormElement) => e.id === parent.position + 1);
-            return nextElements.length == 1 ? nextElements[0] : null;
+            let parentSection: Section = this.getParentSection(formElements);
+            let followingPosition: number = parentSection.position + 1;
+            return formElements.all.find((e: FormElement) => e.position === followingPosition);
         }
 
         // Case formElement is section without target or just a solo question
-        let nextPosition: number = this.position + 1;
-        let nextElements: FormElement[] = formElements.all.filter((e: FormElement) => e.position === nextPosition);
-        return nextElements.length == 1 ? nextElements[0] : null;
+        let followingPosition: number = this.position + 1;
+        return formElements.all.find((e: FormElement) => e.position === followingPosition);
     }
 
     getFollowingFormElementPosition = (formElements: FormElements) : number => {

--- a/common/src/main/resources/ts/models/FormElement/FormElements.ts
+++ b/common/src/main/resources/ts/models/FormElement/FormElements.ts
@@ -1,6 +1,5 @@
-import {Mix, Selection} from "entcore-toolkit";
+import {Selection} from "entcore-toolkit";
 import {idiom, notify} from "entcore";
-import {questionService, sectionService} from "../../services";
 import {Question, Questions} from "./Question";
 import {FormElement} from "./FormElement";
 import {Section, Sections} from "./Section";
@@ -68,6 +67,12 @@ export class FormElements extends Selection<FormElement> {
         questions.all = questions.all.concat(children.flat());
 
         return questions;
+    }
+
+    getAllSectionsAndQuestions = () : FormElement[] => {
+        let sections: FormElement[] = this.getSections().all;
+        let allQuestions: FormElement[] = this.getAllQuestions().all;
+        return sections.concat(allQuestions);
     }
 
     getQuestionById = (questionId: number) : Question => {

--- a/common/src/main/resources/ts/models/FormElement/Section.ts
+++ b/common/src/main/resources/ts/models/FormElement/Section.ts
@@ -2,7 +2,7 @@ import {Mix, Selection} from "entcore-toolkit";
 import {idiom, notify} from "entcore";
 import {sectionService} from "../../services";
 import {FormElement} from "./FormElement";
-import {Questions} from "./Question";
+import {Question, Questions} from "./Question";
 import {FormElementType} from "@common/core/enums/form-element-type";
 import {FormElements} from "@common/models";
 
@@ -47,6 +47,14 @@ export class Section extends FormElement {
         this.next_form_element_id = this.next_form_element ? this.next_form_element.id : null;
         this.next_form_element_type = this.next_form_element ? this.next_form_element.form_element_type : null;
         this.is_next_form_element_default = true;
+    }
+
+    setNextFormElement = (formElements: FormElements) : void => {
+        this.next_form_element = this.getNextFormElement(formElements);
+        let followingFormElement: FormElement = this.getFollowingFormElement(formElements);
+        this.is_next_form_element_default = this.next_form_element ?
+            this.next_form_element.equals(followingFormElement) :
+            followingFormElement == null;
     }
 
     getNextFormElement = (formElements: FormElements) : FormElement => {

--- a/common/src/main/resources/ts/models/QuestionChoice.ts
+++ b/common/src/main/resources/ts/models/QuestionChoice.ts
@@ -52,11 +52,19 @@ export class QuestionChoice {
         }
     }
 
-    setNextFormElementValuesWithDefault = (formElements: FormElements, parent: Question) : void => {
-        this.next_form_element = parent.getFollowingFormElement(formElements);
+    setNextFormElementValuesWithDefault = (formElements: FormElements, parentQuestion: Question) : void => {
+        this.next_form_element = parentQuestion.getFollowingFormElement(formElements);
         this.next_form_element_id = this.next_form_element ? this.next_form_element.id : null;
         this.next_form_element_type = this.next_form_element ? this.next_form_element.form_element_type : null;
         this.is_next_form_element_default = true;
+    }
+
+    setNextFormElement = (formElements: FormElements, parentQuestion: Question) : void => {
+        this.next_form_element = this.getNextFormElement(formElements);
+        let followingFormElement: FormElement = parentQuestion.getFollowingFormElement(formElements);
+        this.is_next_form_element_default = this.next_form_element ?
+            this.next_form_element.equals(followingFormElement) :
+            followingFormElement == null;
     }
 
     getNextFormElement = (formElements: FormElements) : FormElement => {

--- a/common/src/main/resources/ts/utils/formElement.ts
+++ b/common/src/main/resources/ts/utils/formElement.ts
@@ -14,7 +14,6 @@ import {Direction} from "../core/enums";
 import {angular, idiom, notify} from "entcore";
 import {formElementService, questionService} from "../services";
 import {PropPosition} from "@common/core/enums/prop-position";
-import {FormElementType} from "@common/core/enums/form-element-type";
 
 export class FormElementUtils {
     static castFormElement = (formElement: any) : Question|Section => {
@@ -109,11 +108,12 @@ export class FormElementUtils {
     // Drag and drop
 
     static onEndDragAndDrop = async (evt: any, formElements: FormElements) : Promise<void> => {
-        let scopeElem: any = angular.element(evt.item.firstElementChild.firstElementChild).scope().vm;
+        let elem = evt.item.firstElementChild.firstElementChild;
+        let scopeElem = angular.element(elem).scope().vm;
         let itemId: number = scopeElem.question ? scopeElem.question.id : scopeElem.section.id;
-        let newNestedSectionId: number = evt.to.id.split("-")[1] != "0" ? parseInt(evt.to.id.split("-")[1]) : null;
-        let oldNestedContainerId: number = evt.from.id.split("-")[1] != "0" ? parseInt(evt.from.id.split("-")[1]) : null;
-        let oldSection: Section = oldNestedContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldNestedContainerId)[0]) as Section : null;
+        let newSectionId: number = evt.to.id.split("-")[1] != "0" ? parseInt(evt.to.id.split("-")[1]) : null;
+        let oldContainerId: number = evt.from.id.split("-")[1] != "0" ? parseInt(evt.from.id.split("-")[1]) : null;
+        let oldSection: Section = oldContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldContainerId)[0]) as Section : null;
         let item: any = null;
         if (scopeElem.section) {
             item = formElements.all.filter((e: FormElement) => e.id === itemId)[0] as Section;
@@ -127,23 +127,23 @@ export class FormElementUtils {
         let indexes: any = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
 
         // We cannot move a section into another section
-        if (newNestedSectionId && item instanceof Section) {
+        if (newSectionId && item instanceof Section) {
             return;
         }
 
-        if (!newNestedSectionId) {
+        if (!newSectionId) {
             if (oldSection) { // Item moved FROM oldSection TO vm.formElements
                 FormElementUtils.updateSiblingsPositions(oldSection.questions, false, null, oldIndex);
                 FormElementUtils.updateSiblingsPositions(formElements, true, null, newIndex);
                 item.position = newIndex + 1;
                 item.section_id = null;
                 item.section_position = null;
+                oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
                 formElements.all.push(item);
+                FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
                 FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
                 FormElementUtils.updateNextFormElementValues(formElements);
                 await formElementService.update(formElements.all);
-                oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
-                FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
                 FormElementUtils.updateNextFormElementValues(oldSection.questions, formElements);
                 await questionService.update(oldSection.questions.all);
             }
@@ -158,8 +158,8 @@ export class FormElementUtils {
             }
         }
         else {
-            let newSection: Section = (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === newNestedSectionId)[0]) as Section;
-            if (oldSection) { // Item moved FROM oldSection TO section with id 'newNestedSectionId'
+            let newSection: Section = (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === newSectionId)[0]) as Section;
+            if (oldSection) { // Item moved FROM oldSection TO section with id 'newSectionId'
                 if (newSection.id != oldSection.id) {
                     FormElementUtils.updateSiblingsPositions(oldSection.questions, false, null, oldIndex);
                     FormElementUtils.updateSiblingsPositions(newSection.questions, true, null, newIndex);
@@ -168,28 +168,30 @@ export class FormElementUtils {
                     FormElementUtils.updateSiblingsPositions(newSection.questions, true, indexes.goUp, indexes.startIndex, indexes.endIndex);
                 }
                 item.position = null;
-                item.section_id = newNestedSectionId;
+                item.section_id = newSectionId;
                 item.section_position = newIndex + 1;
                 if (newSection.id != oldSection.id) {
                     oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
                     newSection.questions.all.push(item);
+                    FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
+                    FormElementUtils.updateNextFormElementValues(oldSection.questions, formElements);
                 }
-                FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
-                FormElementUtils.updateNextFormElementValues(oldSection.questions, formElements);
+                FormElementUtils.rePositionFormElements(newSection.questions, PropPosition.SECTION_POSITION);
+                FormElementUtils.updateNextFormElementValues(newSection.questions, formElements);
                 await questionService.update(newSection.questions.all.concat(oldSection.questions.all));
             }
-            else { // Item moved FROM vm.formElements TO section with id 'newNestedSectionId'
+            else { // Item moved FROM vm.formElements TO section with id 'newSectionId'
                 FormElementUtils.updateSiblingsPositions(formElements, false, null, oldIndex);
                 FormElementUtils.updateSiblingsPositions(newSection.questions, true, null, newIndex);
                 item.position = null;
-                item.section_id = newNestedSectionId;
+                item.section_id = newSectionId;
                 item.section_position = newIndex + 1;
                 newSection.questions.all.push(item);
+                formElements.all = formElements.all.filter((e: FormElement) => e.id != item.id);
                 FormElementUtils.rePositionFormElements(newSection.questions, PropPosition.SECTION_POSITION);
+                FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
                 FormElementUtils.updateNextFormElementValues(newSection.questions, formElements);
                 await questionService.update(newSection.questions.all);
-                formElements.all = formElements.all.filter((e: FormElement) => e.id != item.id);
-                FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
                 FormElementUtils.updateNextFormElementValues(formElements);
                 await formElementService.update(formElements.all);
             }
@@ -198,40 +200,42 @@ export class FormElementUtils {
 
     static onEndOrgaDragAndDrop = async (evt: any, formElements: FormElements) : Promise<boolean> => {
         let elem = evt.item.firstElementChild.firstElementChild;
-        let scopElem = angular.element(elem).scope().vm;
-        let itemId = scopElem.formElement.id;
-        let newNestedSectionId = evt.to.id.split("-")[2] != "0" ? parseInt(evt.to.id.split("-")[2]) : null;
-        newNestedSectionId ? elem.classList.add("sectionChild") : elem.classList.remove("sectionChild");
-        let oldNestedContainerId = evt.from.id.split("-")[2] != "0" ? parseInt(evt.from.id.split("-")[2]) : null;
-        let oldSection = oldNestedContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldNestedContainerId)[0]) as Section: null;
-        let item = null;
-        if (scopElem.section) {
+        let scopeElem = angular.element(elem).scope().vm;
+        let itemId: number = scopeElem.formElement.id;
+        let newSectionId: number = evt.to.id.split("-")[2] != "0" ? parseInt(evt.to.id.split("-")[2]) : null;
+        newSectionId ? elem.classList.add("sectionChild") : elem.classList.remove("sectionChild");
+        let oldContainerId: number = evt.from.id.split("-")[2] != "0" ? parseInt(evt.from.id.split("-")[2]) : null;
+        let oldSection: Section = oldContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldContainerId)[0]) as Section : null;
+        let item: any = null;
+        if (scopeElem.section) {
             item = formElements.all.filter((e: FormElement) => e.id === itemId)[0] as Section;
         }
         else {
-            let oldSiblings = oldSection ? oldSection.questions : formElements;
-            item = (oldSiblings as any).all.filter((q: Question) => q.id === itemId)[0] as Question;
+            let oldSiblings: any = oldSection ? oldSection.questions : formElements;
+            item = oldSiblings.all.filter((q: Question) => q.id === itemId)[0] as Question;
         }
-        let oldIndex = evt.oldIndex;
-        let newIndex = evt.newIndex;
-        let indexes = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
+        let oldIndex: number = evt.oldIndex;
+        let newIndex: number = evt.newIndex;
+        let indexes: any = FormElementUtils.getStartEndIndexes(newIndex, oldIndex);
 
         // We cannot move a section into another section
-        if (newNestedSectionId && item instanceof Section) {
+        if (newSectionId && item instanceof Section) {
             return true;
         }
 
-        if (!newNestedSectionId) {
+        if (!newSectionId) {
             if (oldSection) { // Item moved FROM oldSection TO vm.formElements
                 FormElementUtils.updateSiblingsPositions(oldSection.questions, false, null, oldIndex);
                 FormElementUtils.updateSiblingsPositions(formElements, true, null, newIndex);
                 item.position = newIndex + 1;
                 item.section_id = null;
                 item.section_position = null;
-                oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
                 formElements.all.push(item);
+                oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
+                FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
                 FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
-                // TODO updateNextFormElementValues()
+                FormElementUtils.updateNextFormElementValues(formElements);
+                FormElementUtils.updateNextFormElementValues(oldSection.questions, formElements);
             }
             else { // Item moved FROM vm.formElements TO vm.formElements
                 FormElementUtils.updateSiblingsPositions(formElements, true, indexes.goUp, indexes.startIndex, indexes.endIndex);
@@ -239,12 +243,12 @@ export class FormElementUtils {
                 item.section_id = null;
                 item.section_position = null;
                 FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
-                // TODO updateNextFormElementValues()
+                FormElementUtils.updateNextFormElementValues(formElements);
             }
         }
         else {
-            let newSection = (formElements.all.filter(e => e instanceof Section && e.id === newNestedSectionId)[0]) as Section;
-            if (oldSection) { // Item moved FROM oldSection TO section with id 'newNestedSectionId'
+            let newSection: Section = (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === newSectionId)[0]) as Section;
+            if (oldSection) { // Item moved FROM oldSection TO section with id 'newSectionId'
                 if (newSection.id != oldSection.id) {
                     FormElementUtils.updateSiblingsPositions(oldSection.questions, false, null, oldIndex);
                     FormElementUtils.updateSiblingsPositions(newSection.questions, true, null, newIndex);
@@ -253,27 +257,29 @@ export class FormElementUtils {
                     FormElementUtils.updateSiblingsPositions(newSection.questions, true, indexes.goUp, indexes.startIndex, indexes.endIndex);
                 }
                 item.position = null;
-                item.section_id = newNestedSectionId;
+                item.section_id = newSectionId;
                 item.section_position = newIndex + 1;
                 if (newSection.id != oldSection.id) {
                     oldSection.questions.all = oldSection.questions.all.filter((q: Question) => q.id != item.id);
                     newSection.questions.all.push(item);
                     FormElementUtils.rePositionFormElements(oldSection.questions, PropPosition.SECTION_POSITION);
+                    FormElementUtils.updateNextFormElementValues(oldSection.questions, formElements);
                 }
                 FormElementUtils.rePositionFormElements(newSection.questions, PropPosition.SECTION_POSITION);
-                // TODO updateNextFormElementValues()
+                FormElementUtils.updateNextFormElementValues(newSection.questions, formElements);
             }
-            else { // Item moved FROM vm.formElements TO section with id 'newNestedSectionId'
+            else { // Item moved FROM vm.formElements TO section with id 'newSectionId'
                 FormElementUtils.updateSiblingsPositions(formElements, false, null, oldIndex);
                 FormElementUtils.updateSiblingsPositions(newSection.questions, true, null, newIndex);
                 item.position = null;
-                item.section_id = newNestedSectionId;
+                item.section_id = newSectionId;
                 item.section_position = newIndex + 1;
                 newSection.questions.all.push(item);
                 formElements.all = formElements.all.filter((e: FormElement) => e.id != item.id);
-                FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
                 FormElementUtils.rePositionFormElements(newSection.questions, PropPosition.SECTION_POSITION);
-                // TODO updateNextFormElementValues()
+                FormElementUtils.rePositionFormElements(formElements, PropPosition.POSITION);
+                FormElementUtils.updateNextFormElementValues(newSection.questions, formElements);
+                FormElementUtils.updateNextFormElementValues(formElements);
             }
         }
 
@@ -352,7 +358,7 @@ export class FormElementUtils {
             }
             else if (element instanceof Section && !element.is_next_form_element_default) {
                 let nextElementPosition: number = element.getNextFormElementPosition(formElements);
-                if (nextElementPosition <= element.position) {
+                if (nextElementPosition && nextElementPosition <= element.position) {
                     element.setNextFormElementValuesWithDefault(formElements);
                 }
             }
@@ -361,9 +367,9 @@ export class FormElementUtils {
                     if (choice.is_next_form_element_default) {
                         choice.setNextFormElementValuesWithDefault(formElements, element);
                     }
-                    if (!choice.is_next_form_element_default) {
+                    else {
                         let nextElementPosition: number = choice.getNextFormElementPosition(formElements);
-                        if (nextElementPosition <= element.getPosition(formElements)) {
+                        if (nextElementPosition && nextElementPosition <= element.getPosition(formElements)) {
                             choice.setNextFormElementValuesWithDefault(formElements, element);
                         }
                     }

--- a/formulaire/src/main/java/fr/openent/formulaire/service/QuestionChoiceService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/QuestionChoiceService.java
@@ -7,6 +7,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.List;
+
 public interface QuestionChoiceService {
     /**
      * List all the choices of a specific question
@@ -52,6 +54,13 @@ public interface QuestionChoiceService {
      * @param locale locale language
      */
     Future<JsonObject> update(QuestionChoice choice, String locale);
+
+    /**
+     * Update a list of specific choices
+     * @param choices List<QuestionChoice> data
+     * @param locale locale language
+     */
+    Future<JsonArray> update(List<QuestionChoice> choices, String locale);
 
     /**
      * Delete a specific choice

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -251,7 +251,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 }
             }
 
-            await formElementService.update(vm.formElements.all);
+            await formElementService.update(vm.formElements.getAllSectionsAndQuestions());
             vm.display.lightbox.reorganization = false;
             template.close('lightbox');
             $scope.safeApply();

--- a/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-singleanswer/question-type-singleanswer.html
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-singleanswer/question-type-singleanswer.html
@@ -28,7 +28,7 @@
         <i class="i-cancel lg-icon dontSave" ng-click="vm.deleteChoice($index)" ng-if="vm.question.selected && !vm.hasFormResponses"></i>
         <select class="five" ng-if="vm.question.conditional" ng-model="choice.next_form_element"
                 ng-change="vm.onSelectOption(choice)" ng-disabled="!vm.question.selected" input-guard>
-            <option ng-if="vm.getNextElement() != null" ng-value="vm.getNextElement()">[[vm.i18n.translate('formulaire.access.next')]]</option>
+            <option ng-if="vm.followingFormElement != null" ng-value="vm.followingFormElement">[[vm.i18n.translate('formulaire.access.next')]]</option>
             <option ng-repeat="formElement in vm.formElements.all | filter:vm.filterNextElements | orderBy:['position', 'id']" ng-value="formElement">
                 [[vm.i18n.translate('formulaire.access.element') + formElement.title]]
             </option>

--- a/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
@@ -71,7 +71,7 @@
                 <!-- Next element selector -->
                 <select class="four dontSave" ng-if="!vm.section.selected && !vm.hasConditional()" input-guard
                         ng-model="vm.section.next_form_element" ng-change="vm.onSelectOption()">
-                    <option ng-if="vm.getNextElement() != null" ng-value="vm.getNextElement()">[[vm.i18n.translate('formulaire.access.next')]]</option>
+                    <option ng-if="vm.followingFormElement != null" ng-value="vm.followingFormElement">[[vm.i18n.translate('formulaire.access.next')]]</option>
                     <option ng-repeat="formElement in vm.formElements.all | filter:vm.filterNextElements | orderBy:['position', 'id']" ng-value="formElement">
                         [[vm.i18n.translate('formulaire.access.element') + formElement.title]]
                     </option>

--- a/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultQuestionChoiceServiceTest.java
+++ b/formulaire/src/test/java/fr/openent/formulaire/service/test/impl/DefaultQuestionChoiceServiceTest.java
@@ -1,6 +1,9 @@
 package fr.openent.formulaire.service.test.impl;
 
+import fr.openent.form.core.models.FormElement;
+import fr.openent.form.core.models.Question;
 import fr.openent.form.core.models.QuestionChoice;
+import fr.openent.form.core.models.Section;
 import fr.openent.formulaire.service.impl.DefaultQuestionChoiceService;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -12,6 +15,10 @@ import org.entcore.common.sql.Sql;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static fr.openent.form.core.constants.EbFields.FORMULAIRE_ADDRESS;
 import static fr.openent.form.core.constants.Fields.*;
@@ -65,7 +72,7 @@ public class DefaultQuestionChoiceServiceTest {
     }
 
     @Test
-    public void testUpdate(TestContext ctx) {
+    public void testUpdate_oneChoice(TestContext ctx) {
         Async async = ctx.async();
         String locale = "fr";
 


### PR DESCRIPTION
## Describe your changes
The previously implemented targetting system is know adapting when form elements are drag and drop from editor view or organization pop up

## Checklist tests
Play with drag and drop in editor view or organization pop up  and check that targetting values are still logic after each move

## Issue ticket number and link
FOR-531 : https://jira.support-ent.fr/browse/FOR-531

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)