### PR TITLE
fix(orga-popup): [#FOR-607] fix drag and drop in reorganization pop-up

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
@@ -24,6 +24,7 @@ import org.entcore.common.http.filter.ResourceFilter;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -96,6 +97,7 @@ public class FormElementController extends ControllerHelper {
             // Check doubles inside
             JsonArray positions = UtilsHelper.getByProp(formElementsJson, POSITION);
             Set<Object> doubles = positions.stream()
+                    .filter(Objects::nonNull) // We don't check the questions inside sections
                     .filter(i -> Collections.frequency(positions.getList(), i) > 1)
                     .collect(Collectors.toSet());
             if (doubles.size() > 0) {


### PR DESCRIPTION
## Describe your changes
Fix drag and drop in reorganization pop-up.
When saving we got sections, questions and questions inside sections. These last questions have all null positions, making the checking fail in back checking. So we filter these for ou check which is only about the main form elements.

## Checklist tests

## Issue ticket number and link
FOR-607 : https://jira.support-ent.fr/browse/FOR-607

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)