### PR TITLE
fix(export): #FOR-625 change right reference in checkFormsRight call for exporting

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -1117,7 +1117,7 @@ public class FormController extends ControllerHelper {
                     groupsAndUserIds.addAll(user.getGroupsIds());
                 }
 
-                formService.checkFormsRights(groupsAndUserIds, user, MANAGER_RESOURCE_RIGHT, formIds, hasRightsEvt -> {
+                formService.checkFormsRights(groupsAndUserIds, user, MANAGER_RESOURCE_BEHAVIOUR, formIds, hasRightsEvt -> {
                     if (hasRightsEvt.isLeft()) {
                         log.error("[Formulaire@exportForms] Fail to check rights for method " + hasRightsEvt);
                         renderInternalError(request, hasRightsEvt);

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
@@ -1,8 +1,8 @@
 package fr.openent.formulaire.service.impl;
 
 import fr.openent.form.core.enums.I18nKeys;
-import fr.openent.form.helpers.I18nHelper;
 import fr.openent.form.helpers.FutureHelper;
+import fr.openent.form.helpers.I18nHelper;
 import fr.openent.formulaire.service.FormService;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
@@ -26,8 +26,6 @@ import static fr.openent.form.core.constants.DistributionStatus.FINISHED;
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.*;
 import static fr.openent.form.core.constants.Tables.*;
-import static fr.openent.form.helpers.SqlHelper.getParamsForUpdateDateModifFormRequest;
-import static fr.openent.form.helpers.SqlHelper.getUpdateDateModifFormRequest;
 
 public class DefaultFormService implements FormService {
     private final Sql sql = Sql.getInstance();
@@ -531,7 +529,7 @@ public class DefaultFormService implements FormService {
         String query = "SELECT COUNT(DISTINCT f.id) FROM " + FORM_TABLE + " f " +
                 "LEFT JOIN " + FORM_SHARES_TABLE + " fs ON fs.resource_id = f.id " +
                 "WHERE ((member_id IN " + Sql.listPrepared(groupsAndUserIds) + " AND action = ?) OR owner_id = ?) AND id IN " + Sql.listPrepared(formIds);
-        JsonArray params = (new fr.wseduc.webutils.collections.JsonArray(groupsAndUserIds))
+        JsonArray params = (new JsonArray(groupsAndUserIds))
                 .add(right)
                 .add(user.getUserId())
                 .addAll(formIds);


### PR DESCRIPTION
## Describe your changes
When a form was shared with a user (with manager rights), he could not export the form.
This bug was due to a wrong right parameter passed in the the checkFormsRights method of the formService.
The right passed was MANAGER_RESOURCE_RIGHT instead of MANAGER_RESOURCE_BEHAVIOUR and the pgsql query could not find anything, so we got a 401 error.

## Checklist tests

## Issue ticket number and link
https://jira.support-ent.fr/browse/FOR-625
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)