### PR TITLE
feat(share): #FOR-626 add planet icon to form when public

### DIFF
--- a/formulaire/src/main/resources/public/template/containers/forms-list.html
+++ b/formulaire/src/main/resources/public/template/containers/forms-list.html
@@ -136,6 +136,7 @@
                                     <i class="i-send md-icon" ng-if="form.sent && !form.archived" title="[[vm.getTitle('sent')]]"></i>
                                     <i class="i-share md-icon" ng-if="form.collab" title="[[vm.getTitle('shared')]]"></i>
                                     <i class="i-bell md-icon" ng-if="form.reminded" title="[[vm.getTitle('reminded')]]"></i>
+                                    <i class="i-earth md-icon" ng-if="form.is_public" title="[[vm.getTitle('public')]]"></i>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Describe your changes
In list view, when a form was made to be public, a planet icon now appears in the right down border of form card.

This PR is related to the CSS PR :
https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/pull/65

## Checklist tests
Create a form and check public status.
When coming back in the main page, the ticket has a planet on it.

## Issue ticket number and link
https://jira.support-ent.fr/browse/FOR-626
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)