### PR TITLE
fix(public): #FOR-563 display pictures in public form response

### DIFF
--- a/formulaire/src/main/resources/public/template/containers/edit-form.html
+++ b/formulaire/src/main/resources/public/template/containers/edit-form.html
@@ -41,33 +41,38 @@
                                    question="formElement"
                                    reorder="true"
                                    has-form-responses="vm.form.nb_responses > 0"
-                                   form-elements="vm.formElements">
+                                   form-elements="vm.formElements"
+                                   form="vm.form">
                     </question-item>
                     <!--  Section component -->
                     <section-item ng-if="!FormElementUtils.isQuestion(formElement)"
                                   section="formElement"
                                   reorder="true"
                                   has-form-responses="vm.form.nb_responses > 0"
-                                  form-elements="vm.formElements">
+                                  form-elements="vm.formElements"
+                                  form="vm.form">
                     </section-item>
                 </div>
             </div>
             <!-- List of formElements mobile -->
             <div class="elements" ng-if="isMobile || (!isMobile && vm.formElements.selected.length > 0) || vm.form.nb_responses > 0">
+
                 <div ng-repeat="formElement in vm.formElements.all | orderBy:'position'" class="twelve twelve-mobile">
                     <!--  Question component -->
                     <question-item ng-if="FormElementUtils.isQuestion(formElement)"
                                    question="formElement"
                                    reorder="false"
                                    has-form-responses="vm.form.nb_responses > 0"
-                                   form-elements="vm.formElements">
+                                   form-elements="vm.formElements"
+                                   form="vm.form">
                     </question-item>
                     <!--  Section component -->
                     <section-item ng-if="!FormElementUtils.isQuestion(formElement)"
                                   section="formElement"
                                   reorder="false"
                                   has-form-responses="vm.form.nb_responses > 0"
-                                  form-elements="vm.formElements">
+                                  form-elements="vm.formElements"
+                                  form="vm.form">
                     </section-item>
                 </div>
             </div>

--- a/formulaire/src/main/resources/public/ts/directives/question/question-item/question-item.directive.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-item/question-item.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, idiom, ng} from "entcore";
-import {FormElement, FormElements, Question, Section, Types} from "@common/models";
+import {Form, FormElement, FormElements, Question, Section, Types} from "@common/models";
 import {FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
 import {Constants} from "@common/core/constants";
 import {RootsConst} from "../../../core/constants/roots.const";
@@ -7,6 +7,7 @@ import {IScope} from "angular";
 
 interface IQuestionItemProps {
     question: Question;
+    form: Form;
     reorder: boolean;
     hasFormResponses: boolean;
     formElements: FormElements;
@@ -32,6 +33,7 @@ interface IQuestionItemScope extends IScope, IQuestionItemProps{
 
 class Controller implements IViewModel {
     question: Question;
+    form: Form;
     reorder: boolean;
     hasFormResponses: boolean;
     formElements: FormElements;
@@ -135,6 +137,7 @@ function directive() {
         transclude: true,
         scope: {
             question: '=',
+            form: '<',
             reorder: '=',
             hasFormResponses: '=',
             formElements: '<'

--- a/formulaire/src/main/resources/public/ts/directives/question/question-item/question-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-item/question-item.html
@@ -20,7 +20,8 @@
             <question-type question="vm.question"
                            has-form-responses="vm.hasFormResponses"
                            form-elements="vm.formElements"
-                           matrix-type="vm.matrixType">
+                           matrix-type="vm.matrixType"
+                           form="vm.form">
             </question-type>
             <!-- Interaction buttons-->
             <div class="question-bottom" ng-if="vm.question.selected">

--- a/formulaire/src/main/resources/public/ts/directives/question/question-type.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-type.ts
@@ -1,8 +1,9 @@
 import {Directive, ng} from "entcore";
-import {FormElements, Question, Types} from "@common/models";
+import {Form, FormElements, Question, Types} from "@common/models";
 
 interface IViewModel {
     question: Question;
+    form: Form;
     hasFormResponses: boolean;
     types: typeof Types;
     formElements: FormElements;
@@ -16,6 +17,7 @@ export const questionType: Directive = ng.directive('questionType', () => {
         transclude: true,
         scope: {
             question: '=',
+            form: '<',
             hasFormResponses: '=',
             formElements: '<',
             matrixType: '<'
@@ -26,7 +28,8 @@ export const questionType: Directive = ng.directive('questionType', () => {
             <div class="question-type focusable">
                 <!-- FREETEXT -->
                 <question-type-freetext ng-if="vm.question.question_type == vm.types.FREETEXT"
-                                        question="vm.question">
+                                        question="vm.question"
+                                        form="vm.form">
                 </question-type-freetext>
                 <!-- SHORTANSWER -->
                 <question-type-shortanswer ng-if="vm.question.question_type == vm.types.SHORTANSWER"

--- a/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-freetext.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-freetext.ts
@@ -1,9 +1,10 @@
 import {ng} from "entcore";
-import {Question} from "@common/models";
+import {Form, Question} from "@common/models";
 import {IScope} from "angular";
 
 interface IQuestionTypeFreetextProps {
     question: Question;
+    form: Form;
 }
 
 interface IViewModel extends ng.IController, IQuestionTypeFreetextProps {
@@ -16,6 +17,7 @@ interface IQuestionTypeFreetextScope extends IScope, IQuestionTypeFreetextProps 
 
 class Controller implements IViewModel {
     question: Question;
+    form: Form;
 
     constructor(private $scope: IQuestionTypeFreetextScope, private $sce: ng.ISCEService) {}
 
@@ -34,7 +36,8 @@ function directive() {
         restrict: 'E',
         transclude: true,
         scope: {
-            question: '='
+            question: '=',
+            form: '<',
         },
         controllerAs: 'vm',
         bindToController: true,
@@ -45,7 +48,7 @@ function directive() {
                     <textarea disabled ng-if="!vm.question.statement" i18n-placeholder="formulaire.question.type.FREETEXT"></textarea>
                 </div>
                 <div ng-if="vm.question.selected">
-                    <editor ng-model="vm.question.statement" input-guard></editor>
+                    <editor ng-model="vm.question.statement" visibility="vm.form.is_public ? 'public' : ''" input-guard></editor>
                 </div>
             </div>
         `,

--- a/formulaire/src/main/resources/public/ts/directives/section-item/section-item.directive.ts
+++ b/formulaire/src/main/resources/public/ts/directives/section-item/section-item.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, idiom, ng} from "entcore";
-import {FormElement, FormElements, Question, Section} from "@common/models";
+import {Form, FormElement, FormElements, Question, Section} from "@common/models";
 import {FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
 import {I18nUtils} from "@common/utils";
 import {RootsConst} from "../../core/constants/roots.const";
@@ -42,6 +42,7 @@ class Controller implements IViewModel {
     hasFormResponses: boolean;
     followingFormElement: FormElement;
     formElements: FormElements;
+    form: Form;
     i18n: I18nUtils;
 
     constructor(private $scope: ISectionItemScope, private $sce: ng.ISCEService) {
@@ -126,7 +127,8 @@ function directive() {
             section: '=',
             reorder: '=',
             hasFormResponses: '=',
-            formElements: '<'
+            formElements: '<',
+            form: '<'
         },
         controllerAs: 'vm',
         bindToController: true,

--- a/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
@@ -43,7 +43,7 @@
                     <div ng-if="!vm.section.description" class="nodescription"><i18n>formulaire.section.no.description</i18n></div>
                 </div>
                 <div class="dontSave" ng-if="vm.section.selected">
-                    <editor ng-model="vm.section.description" input-guard></editor>
+                    <editor ng-model="vm.section.description" visibility="vm.form.is_public ? 'public' : ''" input-guard></editor>
                 </div>
             </div>
             <!-- Questions children -->
@@ -52,7 +52,8 @@
                     <question-item question="question"
                                    reorder="vm.reorder"
                                    has-form-responses="vm.hasFormResponses"
-                                   form-elements="vm.formElements">
+                                   form-elements="vm.formElements"
+                                   form="vm.form">
                     </question-item>
                 </div>
             </div>
@@ -61,7 +62,8 @@
                     <question-item question="question"
                                    reorder="vm.reorder"
                                    has-form-responses="vm.hasFormResponses"
-                                   form-elements="vm.formElements">
+                                   form-elements="vm.formElements"
+                                   form="vm.form">
                     </question-item>
                 </div>
             </div>


### PR DESCRIPTION
## Describe your changes
*When sharing a public form, the responder can't access directly to the emitter's workspace to load the pictures.*
*These public pictures must be stored in a separate folder called "pub". To do that, we have to add the "visibility" property to the "editor" tag (which represents the WISIWYG editor).*

e.g : `<editor ng-model="vm.question.statement" visiblity="vm.form.is_public" input-guard></editor>`

*Visibility gets form's "is_public" property and set its value to 'public' if true or empty if false.*
*To pass this boolean value to the directive, the object "form" has been passed from every question type to its children.*

## Checklist tests
*Create a public form and add a picture in question text area.*
*Also try by adding a section and put a picture in the description.*

*When openeing the form link in your browser (in private mode), the picture must appear.*

## Issue ticket number and link
[FOR-563](https://jira.support-ent.fr/browse/FOR-563)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)