### PR TITLE
fix(treeForm): #FOR-646 resize height of graph to be responsive

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
@@ -72,11 +72,11 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
 
             // Center the graph
             const vw: number = window.innerWidth - (window.innerWidth * 8 / 100);
-            svg.attr('width', vw);
+            const vh: number = window.innerHeight - (window.innerHeight * 30 / 100);
+            svg.attr('width', vw).attr('height', vh);
             let initialScale: number = 0.75;
             if(mainGraph != null){
                 svg.call(zoom.transform, d3.zoomIdentity.translate((svg.attr("width") - mainGraph.graph().width * initialScale) / 2, 20).scale(initialScale));
-                svg.attr('height', mainGraph.graph().height * initialScale + 300);
             }
         }
 


### PR DESCRIPTION
## Describe your changes
*In order to add a border around the svg, the height of the graph was resized with the help of window.innerheight.*
*Now the entire svg border fits to the screen of any viewport.*

*This PR is linked to CSS PR :*
https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/pull/77

## Checklist tests
*In form module, select a form to edit it and click on "visualiser le parcours".*
*Yo should see the form graph vue with a gray border around as shown on the picture.*
![border](https://github.com/OPEN-ENT-NG/form/assets/72068635/3d2320e9-8cae-48d3-950a-c93413fffc59)


## Issue ticket number and link
[FOR-646](https://jira.support-ent.fr/browse/FOR-646)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)