### PR TITLE
fix(new-element): [#FOR-663] fix element created in position 2 instead of at the end of the form

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -64,6 +64,7 @@ interface ViewModel {
     PreviewPage: typeof PreviewPage;
     nestedSortables: any[];
     iconUtils: IconUtils;
+    initializing: boolean;
 
     $onInit() : Promise<void>;
 
@@ -119,6 +120,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         vm.iconUtils = IconUtils;
 
         vm.$onInit = async () : Promise<void> => {
+            vm.initializing = true;
             vm.form = $scope.form;
             vm.form.nb_responses = vm.form.id ? (await distributionService.count(vm.form.id)).count : 0;
             await vm.formElements.sync(vm.form.id);
@@ -128,6 +130,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             $scope.safeApply();
 
             initNestedSortables();
+            vm.initializing = false;
             $scope.safeApply();
         };
 
@@ -208,6 +211,13 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         vm.doCreateNewElement = async (code?, parentSection?) => {
             vm.dontSave = true;
 
+            if (vm.initializing) {
+                window.setTimeout(() => {
+                    vm.doCreateNewElement(code, parentSection);
+                }, 100);
+                return;
+            }
+
             vm.newElement = code ? new Question() : new Section();
             if (vm.newElement instanceof Question) {
                 vm.newElement.question_type = code;
@@ -242,6 +252,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             vm.display.lightbox.newElement = false;
             template.close('lightbox');
             vm.dontSave = false;
+            window.scrollTo(0, document.body.scrollHeight);
             $scope.safeApply();
         };
 


### PR DESCRIPTION
## Describe your changes
When opening the lightbox to create a new form element, an autosaving of the form elements is triggered behind.
The problem was when clicking to validate the creation of the new element and closing the lightbox this background task was not over, resulting in partial or false values calculated for the new element.
Thus the new element was badly positionned and impossible to save afterward.

## Checklist tests

## Issue ticket number and link
FOR-663 : https://jira.support-ent.fr/browse/FOR-663
FOR-638 : https://jira.support-ent.fr/browse/FOR-638

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)