### PR TITLE
fix(formTreeView): #FOR-687 add id to svg in html to target tag with more accuracy

### DIFF
--- a/formulaire/src/main/resources/public/template/containers/tree-view.html
+++ b/formulaire/src/main/resources/public/template/containers/tree-view.html
@@ -28,7 +28,7 @@
                 <span><i18n>formulaire.scroll.legend</i18n></span>
                 <span><i18n>formulaire.mouse.legend</i18n></span>
             </div>
-            <svg>
+            <svg id="tree-svg">
                 <g></g>
             </svg>
         </div>

--- a/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
@@ -57,7 +57,7 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
             let render: any = new dagreD3.render();
 
             // Set up an SVG group so that we can translate the final graph.
-            let svg: any = d3.select("svg");
+            let svg: any = d3.select("#tree-svg");
             let inner: any = svg.select("g");
 
             //Set up zoom support
@@ -67,7 +67,7 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
             svg.call(zoom);
 
             // Run the renderer. This is what draws the final graph.
-            render_graph(render, nodes, edgeList, inner, svg);
+             render_graph(render, nodes, edgeList, inner, svg);
 
             // Center the graph
             const treeView: any = d3.select(".tree-view");
@@ -133,8 +133,7 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
         }
 
         // Rendering
-
-        const render_graph = (render, nodes, edgeList, inner, svg) : void => {
+        const render_graph = (render, nodes, edgeList, inner, svg): void => {
             let nbTries: number = 100; // try 100 times, if optimal not found, give up
             let iter_cnt: number = 0;
             let optimalArray: any[] | undefined;
@@ -144,7 +143,6 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
                 let list: any[] = TreeUtils.shuffle(edgeList);
                 if (!optimalArray) optimalArray = list;
                 setNodesAndEdges(nodes, edgeList, render, inner);
-
                 let arrows: Arrows = extractArrows(svg);
                 let collisionArrowsCnt: number = arrows.countNbCollisions();
 
@@ -190,34 +188,34 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
             render(inner, g);
         }
 
-        const extractArrows = (svg: any) : Arrows => {
-            let nn = svg.select(".edgePaths");
-            let paths = nn._groups ? nn._groups[0][0] : nn[0][0];
-            let fc = paths.firstChild;
-            let arrows: Arrows = new Arrows();
-            while (fc) {
-                let path = fc.firstChild.getAttribute("d");
-                let coords = path.split(/,|L/)
-                    .map((c: string) => {
+        // On doit attendre que le svg soit chargé pour retourner les arrows dans la promesse
+        const extractArrows = (svg: any): Arrows => {
+                const nn = svg.select(".edgePaths");
+                const paths = nn.node();
+                let fc = paths.firstChild;
+                let arrows: Arrows = new Arrows();
+
+                while (fc) {
+                    let path = fc.firstChild.getAttribute("d");
+                    let coords = path.split(/,|L/).map((c: string) => {
                         let n: string = c;
-                        if ((c[0]=="M" || c[0]=="L")) n = c.substring(1);
+                        if (c[0] === "M" || c[0] === "L") n = c.substring(1);
                         return parseFloat(n);
-                    })
+                    });
 
-                let arrow: Arrow = new Arrow();
-                for (let i = 0; i <= coords.length - 4; i+=2) {
-                    arrow.lines.all.push(new Line(coords[i], coords[i+1], coords[i+2], coords[i+3]));
+                    let arrow: Arrow = new Arrow();
+                    for (let i = 0; i <= coords.length - 4; i += 2) {
+                        arrow.lines.all.push(new Line(coords[i], coords[i + 1], coords[i + 2], coords[i + 3]));
+                    }
+                    arrows.all.push(arrow);
+                    fc = fc.nextSibling;
                 }
-                arrows.all.push(arrow);
+                return arrows;
+            };
 
-                fc = fc.nextSibling;
-            }
 
-            return arrows;
-        }
 
         // HTML
-
         const getHtmlNode = (formElement: FormElement) : string => {
             if (formElement instanceof Question) {
                 return `<div class="tree-view-question">

--- a/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-tree-view.ts
@@ -188,30 +188,29 @@ export const formTreeViewController = ng.controller('FormTreeViewController', ['
             render(inner, g);
         }
 
-        // On doit attendre que le svg soit chargé pour retourner les arrows dans la promesse
         const extractArrows = (svg: any): Arrows => {
-                const nn = svg.select(".edgePaths");
-                const paths = nn.node();
-                let fc = paths.firstChild;
-                let arrows: Arrows = new Arrows();
+            let nn: any = svg.select(".edgePaths");
+            let paths: any = nn.node();
+            let fc = paths.firstChild;
+            let arrows: Arrows = new Arrows();
 
-                while (fc) {
-                    let path = fc.firstChild.getAttribute("d");
-                    let coords = path.split(/,|L/).map((c: string) => {
-                        let n: string = c;
-                        if (c[0] === "M" || c[0] === "L") n = c.substring(1);
-                        return parseFloat(n);
-                    });
+            while (fc) {
+                let path = fc.firstChild.getAttribute("d");
+                let coords = path.split(/,|L/).map((c: string) => {
+                    let n: string = c;
+                    if (c[0] === "M" || c[0] === "L") n = c.substring(1);
+                    return parseFloat(n);
+                });
 
-                    let arrow: Arrow = new Arrow();
-                    for (let i = 0; i <= coords.length - 4; i += 2) {
-                        arrow.lines.all.push(new Line(coords[i], coords[i + 1], coords[i + 2], coords[i + 3]));
-                    }
-                    arrows.all.push(arrow);
-                    fc = fc.nextSibling;
+                let arrow: Arrow = new Arrow();
+                for (let i = 0; i <= coords.length - 4; i += 2) {
+                    arrow.lines.all.push(new Line(coords[i], coords[i + 1], coords[i + 2], coords[i + 3]));
                 }
-                return arrows;
-            };
+                arrows.all.push(arrow);
+                fc = fc.nextSibling;
+            }
+            return arrows;
+        };
 
 
 


### PR DESCRIPTION
## Describe your changes
To populate the svg in DOM, the dagre-D3 librarie needs to target the right svg. But in ng2, a svg was added in the header so the librairie took this svg and the tree graph generation didn't work anymore. So an id was added to the right svg in order to target it and populate it in the controller.
## Checklist tests
Go to ng2 with for example suzie die and choose a form. Than double click on it to go to the form edit page. Then click on "visualiser le parcours".
## Issue ticket number and link
[FOR-687](https://jira.support-ent.fr/browse/FOR-687)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)