### PR TITLE
fix(new-element): [#FOR-685] fix new element creation too fast

### DIFF
--- a/formulaire/src/main/resources/public/template/containers/edit-form.html
+++ b/formulaire/src/main/resources/public/template/containers/edit-form.html
@@ -80,7 +80,7 @@
             <!-- End page buttons -->
             <div class="buttons">
                 <div class="flexend nine zero-mobile">
-                    <button class="cell" id="createNewEltConfirm1" ng-class="{blueButton: vm.form.nb_responses <= 0}"
+                    <button class="cell dontSave" id="createNewEltConfirm1" ng-class="{blueButton: vm.form.nb_responses <= 0}"
                             ng-click="vm.createNewElement()" ng-disabled="vm.form.nb_responses > 0">
                         <i18n>formulaire.add.element</i18n>
                     </button>

--- a/formulaire/src/main/resources/public/template/lightbox/new-element.html
+++ b/formulaire/src/main/resources/public/template/lightbox/new-element.html
@@ -1,23 +1,30 @@
 <lightbox class="new-element dontSave" show="vm.display.lightbox.newElement" on-close="vm.closeLightbox('newElement')">
     <h2><i18n>formulaire.element.new.title</i18n></h2>
-    <div class="section" ng-click="vm.doCreateNewElement()" ng-if="!vm.parentSection">
-        <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
-        <div><i18n>formulaire.element.new.section.description</i18n></div>
-    </div>
-    <div class="question">
-        <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
-        <div class="dominos">
-            <div ng-repeat="type in vm.questionTypes.all" class="item"
-                 ng-click="vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
-                <div class="domino">
-                    <div class="data-text">
-                        <h5>[[vm.displayTypeName(type.name)]]</h5>
-                    </div>
-                    <div class="picture">
-                        <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
+    <div  ng-if="!vm.display.loading">
+        <div class="section" ng-click="vm.doCreateNewElement()" ng-if="!vm.parentSection">
+            <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
+            <div><i18n>formulaire.element.new.section.description</i18n></div>
+        </div>
+        <div class="question">
+            <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
+            <div class="dominos">
+                <div ng-repeat="type in vm.questionTypes.all" class="item"
+                     ng-click="vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
+                    <div class="domino">
+                        <div class="data-text">
+                            <h5>[[vm.displayTypeName(type.name)]]</h5>
+                        </div>
+                        <div class="picture">
+                            <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
+
+    <!-- Loader -->
+    <div ng-if="vm.display.loading" class="twelve loader">
+        <loader min-height="'10px'"/>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -51,7 +51,8 @@ interface ViewModel {
             reorganization: boolean,
             delete: boolean,
             undo: boolean
-        }
+        },
+        loading: boolean
     };
     preview: {
         formElement: FormElement, // Question for preview
@@ -113,7 +114,8 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 reorganization: false,
                 delete: false,
                 undo: false
-            }
+            },
+            loading: false
         };
         vm.PreviewPage = PreviewPage;
         vm.nestedSortables = [];
@@ -201,22 +203,19 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             }
         };
 
-        vm.createNewElement = async (parentSection?) : Promise<void>=> {
+        vm.createNewElement = async (parentSection?) : Promise<void> => {
+            vm.display.loading = true;
             vm.parentSection = parentSection ? parentSection : null;
             template.open('lightbox', 'lightbox/new-element');
             vm.display.lightbox.newElement = true;
+            $scope.safeApply();
+            await saveFormElements(false);
+            vm.display.loading = false;
             $scope.safeApply();
         };
 
         vm.doCreateNewElement = async (code?, parentSection?) => {
             vm.dontSave = true;
-
-            if (vm.initializing) {
-                window.setTimeout(() => {
-                    vm.doCreateNewElement(code, parentSection);
-                }, 100);
-                return;
-            }
 
             vm.newElement = code ? new Question() : new Section();
             if (vm.newElement instanceof Question) {
@@ -246,13 +245,13 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 vm.newElement.position = vm.formElements.all.length + 1;
                 vm.formElements.all.push(vm.newElement);
                 vm.nbFormElements = vm.formElements.all.length;
+                window.scrollTo(0, document.body.scrollHeight);
             }
 
             vm.parentSection = null;
             vm.display.lightbox.newElement = false;
             template.close('lightbox');
             vm.dontSave = false;
-            window.scrollTo(0, document.body.scrollHeight);
             $scope.safeApply();
         };
 


### PR DESCRIPTION
## Describe your changes
When clicking on "Ajouter un éléméent" a pop up open while the form is saved.
The problem is for a huge form saving takes time and the user can click in the pop up to create a new element whereas the saving is not over, causing problems as wrong positions, wrong scroll position, etc.
We fixed it by making waiting  the end of the saving before displaying the content of the pop up.

## Checklist tests

## Issue ticket number and link
FOR-685 : https://jira.support-ent.fr/browse/FOR-685

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)