### PR TITLE
fix(progressBar): #FOR-590 change method of progress bar rendering when answering a form

### DIFF
--- a/common/src/main/resources/ts/directives/progress-bar.ts
+++ b/common/src/main/resources/ts/directives/progress-bar.ts
@@ -3,7 +3,6 @@ import {FormElement} from "../models";
 
 interface IViewModel {
     formElement: FormElement,
-    nbFormElements: number,
     historicPosition: number,
     longestPath: number;
 }

--- a/common/src/main/resources/ts/directives/progress-bar.ts
+++ b/common/src/main/resources/ts/directives/progress-bar.ts
@@ -4,6 +4,7 @@ import {FormElement} from "../models";
 interface IViewModel {
     formElement: FormElement,
     nbFormElements: number
+    longestPath: number;
 }
 
 export const progressBubbleBar: Directive = ng.directive('progressBubbleBar', () => {
@@ -11,15 +12,17 @@ export const progressBubbleBar: Directive = ng.directive('progressBubbleBar', ()
         restrict: 'E',
         scope: {
             formElement: '=',
-            nbFormElements: '='
+            nbFormElements: '=',
+            longestPath: '=',
+            historicPosition: '='
         },
         controllerAs: 'vm',
         bindToController: true,
         template: `
-            <div class="progressbar-container" ng-if="vm.nbFormElements > 1">
+            <div class="progressbar-container" ng-if="vm.longestPath > 0">
                 <ul class="progressbar six twelve-mobile">
-                    <li ng-repeat="n in [].constructor(vm.nbFormElements) track by $index"
-                        ng-class="{ active: $index+1 <= vm.formElement.position }"></li>
+                    <li ng-repeat="n in [].constructor(vm.longestPath) track by $index"
+                    ng-class="{ active: $index+1 <= vm.historicPosition.length }"></li>
                 </ul>
             </div>
         `,

--- a/common/src/main/resources/ts/directives/progress-bar.ts
+++ b/common/src/main/resources/ts/directives/progress-bar.ts
@@ -3,7 +3,8 @@ import {FormElement} from "../models";
 
 interface IViewModel {
     formElement: FormElement,
-    nbFormElements: number
+    nbFormElements: number,
+    historicPosition: number,
     longestPath: number;
 }
 
@@ -12,7 +13,6 @@ export const progressBubbleBar: Directive = ng.directive('progressBubbleBar', ()
         restrict: 'E',
         scope: {
             formElement: '=',
-            nbFormElements: '=',
             longestPath: '=',
             historicPosition: '='
         },

--- a/formulaire/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire/src/main/resources/public/template/containers/respond-question.html
@@ -15,8 +15,7 @@
         </section>
     </div>
 
-    <progress-bubble-bar form-element="vm.formElement" nb-form-elements="vm.nbFormElements" longest-path="vm.longestPath"
-    historic-position="vm.historicPosition"></progress-bubble-bar>
+    <progress-bubble-bar form-element="vm.formElement" longest-path="vm.longestPath" historic-position="vm.historicPosition"></progress-bubble-bar>
 
     <div class="respond-question">
         <div class="nine twelve-mobile">

--- a/formulaire/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire/src/main/resources/public/template/containers/respond-question.html
@@ -15,7 +15,8 @@
         </section>
     </div>
 
-    <progress-bubble-bar form-element="vm.formElement" nb-form-elements="vm.nbFormElements"></progress-bubble-bar>
+    <progress-bubble-bar form-element="vm.formElement" nb-form-elements="vm.nbFormElements" longest-path="vm.longestPath"
+    historic-position="vm.historicPosition"></progress-bubble-bar>
 
     <div class="respond-question">
         <div class="nine twelve-mobile">

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -78,7 +78,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
         if (currentNode.isSection()) {
             let questions: Question[] = (<Section>currentNode).questions.all;
             let conditionalQuestions: any = questions.filter((q: Question) => q.conditional);
-            let choices: any = conditionalQuestions && conditionalQuestions.length > 0 ? conditionalQuestions.flatMap(q => q.choices.all) : null;
+            let choices: Question[] = (conditionalQuestions && conditionalQuestions.length > 0) ? conditionalQuestions.flatMap(q => q.choices.all) : null;
             return findLongestPathInQuestionChoices(choices, currentNode, formElements);
         } else {
             let question: Question = <Question>currentNode;
@@ -94,7 +94,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
             if (!nextElementId) {return 1;}
             return findLongestPathInFormElement(nextElementId, formElements) + 1;
         } else {
-            let tab: any[] = choices.map((choice: any) => {
+            let tab: number[] = choices.map((choice: any) => {
                 if (!choice.next_form_element_id) return 1;
                 return findLongestPathInFormElement(choice.next_form_element_id, formElements);
             });

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -65,7 +65,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
         vm.formElement = vm.formElements.all[$scope.responsePosition - 1];
         vm.nbFormElements = vm.formElements.all.length;
         vm.historicPosition = $scope.historicPosition.length > 0 ? $scope.historicPosition : [1];
-        vm.longestPath = findLongestPath(vm.formElement.id, vm.formElements);
+        vm.longestPath = vm.historicPosition.length + findLongestPath(vm.formElement.id, vm.formElements) - 1;
         initFormElementResponses();
         window.setTimeout(() => vm.loading = false,500);
         $scope.safeApply();
@@ -82,7 +82,8 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 
             if (currentNode.isSection()) {
                 const questions: Question[] = (<Section>currentNode).questions.all;
-                const choices = questions.filter((q: Question) => q.conditional).map(q => q.choices.all);
+                let conditionalQuestions: any = questions.filter((q: Question) => q.conditional);
+                const choices = conditionalQuestions && conditionalQuestions.length > 0 ? conditionalQuestions.flatMap(q => q.choices.all) : null;
 
                 if (!choices || choices.length === 0) {
                     const nextElementId: number = currentNode.getNextFormElementId(nodes);
@@ -94,7 +95,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
                     console.log(currentNode.title, val);
                     return val;
                 } else {
-                    const tab = choices[0].map((choice: any) => {
+                    const tab = choices.map((choice: any) => {
                         if (!choice.next_form_element_id && !currentNode.getNextFormElementId(nodes)) {
                             console.log(currentNode.title, 1);
                             return 1;
@@ -179,8 +180,8 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
         if (prevPosition > 0) {
             await saveResponses();
             vm.formElement = vm.formElements.all[prevPosition - 1];
-            vm.longestPath = findLongestPath(vm.formElement.id, vm.formElements);
             vm.historicPosition.pop();
+            vm.longestPath = vm.historicPosition.length + findLongestPath(vm.formElement.id, vm.formElements) - 1;
             goToFormElement();
         }
     };
@@ -196,6 +197,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
             vm.formElement = vm.formElements.all[nextPosition - 1];
             vm.longestPath = findLongestPath(vm.formElement.id, vm.formElements);
             vm.historicPosition.push(vm.formElement.position);
+            vm.longestPath = vm.historicPosition.length + findLongestPath(vm.formElement.id, vm.formElements) - 1;
             goToFormElement();
         }
         else if (nextPosition !== undefined) {

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -72,29 +72,29 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
     }
 
 
-        const findLongestPathInFormElement = (formElementId: number, formElements: FormElements): number => {
-            const currentNode: FormElement = formElements.all.find((node: FormElement) => node.id === formElementId);
-            if (!currentNode) return 1;
-            if (currentNode.isSection()) {
-                const questions: Question[] = (<Section>currentNode).questions.all;
-                let conditionalQuestions: any = questions.filter((q: Question) => q.conditional);
-                const choices = conditionalQuestions && conditionalQuestions.length > 0 ? conditionalQuestions.flatMap(q => q.choices.all) : null;
-                return findLongestPathInQuestionChoices(choices, currentNode, formElements);
-            } else {
-                const question: Question = <Question>currentNode;
-                const questionChoices: QuestionChoice[] = question.conditional ? question.choices.all : null;
-                return findLongestPathInQuestionChoices(questionChoices, currentNode, formElements);
-            }
-        };
+    const findLongestPathInFormElement = (formElementId: number, formElements: FormElements): number => {
+        let currentNode: FormElement = formElements.all.find((node: FormElement) => node.id === formElementId);
+        if (!currentNode) return 1;
+        if (currentNode.isSection()) {
+            let questions: Question[] = (<Section>currentNode).questions.all;
+            let conditionalQuestions: any = questions.filter((q: Question) => q.conditional);
+            let choices: any = conditionalQuestions && conditionalQuestions.length > 0 ? conditionalQuestions.flatMap(q => q.choices.all) : null;
+            return findLongestPathInQuestionChoices(choices, currentNode, formElements);
+        } else {
+            let question: Question = <Question>currentNode;
+            let questionChoices: QuestionChoice[] = question.conditional ? question.choices.all : null;
+            return findLongestPathInQuestionChoices(questionChoices, currentNode, formElements);
+        }
+    };
 
 
     const findLongestPathInQuestionChoices = (choices: any, currentFormElement: FormElement, formElements: FormElements): number => {
         if (!choices || choices.length === 0) {
-            const nextElementId: number = currentFormElement.getNextFormElementId(formElements);
+            let nextElementId: number = currentFormElement.getNextFormElementId(formElements);
             if (!nextElementId) {return 1;}
             return findLongestPathInFormElement(nextElementId, formElements) + 1;
         } else {
-            const tab = choices.map((choice: any) => {
+            let tab: any[] = choices.map((choice: any) => {
                 if (!choice.next_form_element_id) return 1;
                 return findLongestPathInFormElement(choice.next_form_element_id, formElements);
             });

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -78,7 +78,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
         if (currentNode.isSection()) {
             let questions: Question[] = (<Section>currentNode).questions.all;
             let conditionalQuestions: any = questions.filter((q: Question) => q.conditional);
-            let choices: Question[] = (conditionalQuestions && conditionalQuestions.length > 0) ? conditionalQuestions.flatMap(q => q.choices.all) : null;
+            let choices: Question[] = (conditionalQuestions && conditionalQuestions.length > 0) ? conditionalQuestions.flatMap((q: Question) => q.choices.all) : null;
             return findLongestPathInQuestionChoices(choices, currentNode, formElements);
         } else {
             let question: Question = <Question>currentNode;


### PR DESCRIPTION

![progressBar](https://github.com/OPEN-ENT-NG/form/assets/72068635/b776f726-c4c4-4157-8d4b-9fc01a643869)
![longestPath](https://github.com/OPEN-ENT-NG/form/assets/72068635/97055132-22ad-45bd-9f24-cf1e20bfa275)
## Describe your changes
Now the progress bar takes the longest path each time the user is answering a question. As the form can have some conditional question leading to other parts of the form, the new method calculates the longest path regarding the conditional choices and the different possibilities of user's answers.
## Checklist tests
Open a form with a user whom the form has been shared.
Answer the questions and the progress bar must adapt to your choices.
If you want to check whether the path is correct, open the edit page of the form whith the user who has created it and count the max number of form elements we can answer. You can use the new tree for view to be more confortable.
## Issue ticket number and link
[FOR-590](https://jira.support-ent.fr/browse/FOR-590)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)