### PR TITLE
refacto(sync): [#FOR-689] form-editor optimization on syncing

### DIFF
--- a/common/src/main/resources/ts/models/FormElement/FormElement.ts
+++ b/common/src/main/resources/ts/models/FormElement/FormElement.ts
@@ -65,7 +65,7 @@ export abstract class FormElement implements Selectable {
         // Case formElement is not formElement but question inside a section
         if (this instanceof Question && this.section_id) {
             let parentSection: Section = this.getParentSection(formElements);
-            let followingPosition: number = parentSection.position + 1;
+            let followingPosition: number = parentSection ? parentSection.position + 1 : null;
             return formElements.all.find((e: FormElement) => e.position === followingPosition);
         }
 

--- a/common/src/main/resources/ts/services/FormElement/QuestionService.ts
+++ b/common/src/main/resources/ts/services/FormElement/QuestionService.ts
@@ -6,6 +6,7 @@ import {Mix} from "entcore-toolkit";
 
 export interface QuestionService {
     list(id: number, isForSection?: boolean) : Promise<any>;
+    listAll(id: number) : Promise<any>;
     listChildren(questions: Question[]) : Promise<any>;
     get(questionId: number) : Promise<any>;
     save(question: Question) : Promise<any>;
@@ -16,7 +17,7 @@ export interface QuestionService {
 
 export const questionService: QuestionService = {
 
-    async list (id: number, isForSection: boolean = false) : Promise<any> {
+    async list(id: number, isForSection: boolean = false) : Promise<any> {
         try {
             let parentEntity = isForSection ? 'sections' : 'forms';
             return DataUtils.getData(await http.get(`/formulaire/${parentEntity}/${id}/questions`));
@@ -26,7 +27,16 @@ export const questionService: QuestionService = {
         }
     },
 
-    async listChildren (questions: Question[]) : Promise<any> {
+    async listAll(formId: number) : Promise<any> {
+        try {
+            return DataUtils.getData(await http.get(`/formulaire/forms/${formId}/questions/all`));
+        } catch (err) {
+            notify.error(idiom.translate('formulaire.error.questionService.list'));
+            throw err;
+        }
+    },
+
+    async listChildren(questions: Question[]) : Promise<any> {
         try {
             let questionIds: number[] = questions.map((q: Question) => q.id);
             return DataUtils.getData(await http.get(`/formulaire/questions/children`, { params: questionIds }));

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionController.java
@@ -1,6 +1,7 @@
 package fr.openent.formulaire.controllers;
 
 import fr.openent.form.core.enums.QuestionTypes;
+import fr.openent.form.helpers.BusResultHelper;
 import fr.openent.form.helpers.UtilsHelper;
 import fr.openent.formulaire.security.AccessRight;
 import fr.openent.formulaire.security.CustomShareAndOwner;
@@ -87,6 +88,23 @@ public class QuestionController extends ControllerHelper {
                     .onSuccess(result -> renderJson(request, result))
                     .onFailure(error -> renderError(request));
         });
+    }
+
+    @Get("/forms/:formId/questions/all")
+    @ApiDoc("List all the questions of a specific form")
+    @ResourceFilter(AccessRight.class)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    public void listForFormAndSection(HttpServerRequest request) {
+        String formId = request.getParam(PARAM_FORM_ID);
+
+        questionService.listForFormAndSection(formId)
+                .onSuccess(result -> renderJson(request, result))
+                .onFailure(error -> {
+                    String errorMessage = "[Formulaire@QuestionController::listForFormAndSection] " +
+                            "Failed to list questions for form and sections : " + error.getMessage();
+                    log.error(errorMessage);
+                    renderError(request);
+                });
     }
 
     @Get("/questions/children")

--- a/formulaire/src/main/resources/public/template/containers/edit-form.html
+++ b/formulaire/src/main/resources/public/template/containers/edit-form.html
@@ -80,7 +80,7 @@
             <!-- End page buttons -->
             <div class="buttons">
                 <div class="flexend nine zero-mobile">
-                    <button class="cell dontSave" id="createNewEltConfirm1" ng-class="{blueButton: vm.form.nb_responses <= 0}"
+                    <button class="cell" id="createNewEltConfirm1" ng-class="{blueButton: vm.form.nb_responses <= 0}"
                             ng-click="vm.createNewElement()" ng-disabled="vm.form.nb_responses > 0">
                         <i18n>formulaire.add.element</i18n>
                     </button>

--- a/formulaire/src/main/resources/public/template/lightbox/new-element.html
+++ b/formulaire/src/main/resources/public/template/lightbox/new-element.html
@@ -1,30 +1,23 @@
 <lightbox class="new-element dontSave" show="vm.display.lightbox.newElement" on-close="vm.closeLightbox('newElement')">
     <h2><i18n>formulaire.element.new.title</i18n></h2>
-    <div  ng-if="!vm.display.loading">
-        <div class="section" ng-click="vm.doCreateNewElement()" ng-if="!vm.parentSection">
-            <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
-            <div><i18n>formulaire.element.new.section.description</i18n></div>
-        </div>
-        <div class="question">
-            <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
-            <div class="dominos">
-                <div ng-repeat="type in vm.questionTypes.all" class="item"
-                     ng-click="vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
-                    <div class="domino">
-                        <div class="data-text">
-                            <h5>[[vm.displayTypeName(type.name)]]</h5>
-                        </div>
-                        <div class="picture">
-                            <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
-                        </div>
+    <div class="section" ng-click="vm.doCreateNewElement()" ng-if="!vm.parentSection">
+        <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
+        <div><i18n>formulaire.element.new.section.description</i18n></div>
+    </div>
+    <div class="question">
+        <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
+        <div class="dominos">
+            <div ng-repeat="type in vm.questionTypes.all" class="item"
+                 ng-click="vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
+                <div class="domino">
+                    <div class="data-text">
+                        <h5>[[vm.displayTypeName(type.name)]]</h5>
+                    </div>
+                    <div class="picture">
+                        <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-
-    <!-- Loader -->
-    <div ng-if="vm.display.loading" class="twelve loader">
-        <loader min-height="'10px'"/>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -51,8 +51,7 @@ interface ViewModel {
             reorganization: boolean,
             delete: boolean,
             undo: boolean
-        },
-        loading: boolean
+        }
     };
     preview: {
         formElement: FormElement, // Question for preview
@@ -114,8 +113,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 reorganization: false,
                 delete: false,
                 undo: false
-            },
-            loading: false
+            }
         };
         vm.PreviewPage = PreviewPage;
         vm.nestedSortables = [];
@@ -204,13 +202,9 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         };
 
         vm.createNewElement = async (parentSection?) : Promise<void> => {
-            vm.display.loading = true;
             vm.parentSection = parentSection ? parentSection : null;
             template.open('lightbox', 'lightbox/new-element');
             vm.display.lightbox.newElement = true;
-            $scope.safeApply();
-            await saveFormElements(false);
-            vm.display.loading = false;
             $scope.safeApply();
         };
 


### PR DESCRIPTION
## Describe your changes
We optimized the syncing of a form (or rather a list of form elements) by doing only 4 API calls. So it's now independant of the number of elements, choices, etc. Then we simply, map our objects to link everything (sections, questions, choices, etc.)

These API calls are :
- get all sections
- get all questions (including the ones inside sections)
- get all choices for these questions
- get all children for these questions (children are lines of a question matrix)

Thanks to this we were able to revert a temporary fix made here : https://github.com/OPEN-ENT-NG/form/pull/304

## Checklist tests

## Issue ticket number and link
FOR-689 : https://jira.support-ent.fr/browse/FOR-689

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)