### PR TITLE
fix(DnD): [#FOR-639] fix drag and drop in organization lightbox

### DIFF
--- a/common/src/main/resources/ts/utils/formElement.ts
+++ b/common/src/main/resources/ts/utils/formElement.ts
@@ -111,19 +111,19 @@ export class FormElementUtils {
     // Drag and drop
 
     static onEndDragAndDrop = async (evt: any, formElements: FormElements) : Promise<void> => {
-        let elem = evt.item.firstElementChild.firstElementChild;
-        let scopeElem = angular.element(elem).scope().vm;
-        let itemId: number = scopeElem.question ? scopeElem.question.id : scopeElem.section.id;
         let newSectionId: number = evt.to.id.split("-")[1] != "0" ? parseInt(evt.to.id.split("-")[1]) : null;
         let oldContainerId: number = evt.from.id.split("-")[1] != "0" ? parseInt(evt.from.id.split("-")[1]) : null;
         let oldSection: Section = oldContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldContainerId)[0]) as Section : null;
         let item: any = null;
-        if (scopeElem.section) {
-            item = formElements.all.filter((e: FormElement) => e.id === itemId)[0] as Section;
+        if (evt.item.childElementCount === 2) {
+            item = formElements.all[evt.oldIndex] as Section;
         }
-        else {
+        else if (evt.item.childElementCount === 1) {
             let oldSiblings: any = oldSection ? oldSection.questions : formElements;
-            item = oldSiblings.all.filter((e: FormElement) => e.id === itemId)[0] as Question;
+            item = oldSiblings.all[evt.oldIndex] as Question;
+        }
+        else { // Error, it should be either 1 or 2 (Question or Section)
+            return;
         }
         let oldIndex: number = evt.oldIndex;
         let newIndex: number = evt.newIndex;
@@ -199,20 +199,21 @@ export class FormElementUtils {
     };
 
     static onEndOrgaDragAndDrop = async (evt: any, formElements: FormElements) : Promise<boolean> => {
-        let elem = evt.item.firstElementChild.firstElementChild;
-        let scopeElem = angular.element(elem).scope().vm;
-        let itemId: number = scopeElem.formElement.id;
+        let elem: HTMLElement = evt.item.firstElementChild.firstElementChild;
         let newSectionId: number = evt.to.id.split("-")[2] != "0" ? parseInt(evt.to.id.split("-")[2]) : null;
         newSectionId ? elem.classList.add("sectionChild") : elem.classList.remove("sectionChild");
         let oldContainerId: number = evt.from.id.split("-")[2] != "0" ? parseInt(evt.from.id.split("-")[2]) : null;
         let oldSection: Section = oldContainerId ? (formElements.all.filter((e: FormElement) => e instanceof Section && e.id === oldContainerId)[0]) as Section : null;
         let item: any = null;
-        if (scopeElem.section) {
-            item = formElements.all.filter((e: FormElement) => e.id === itemId)[0] as Section;
+        if (evt.item.childElementCount === 2) {
+            item = formElements.all[evt.oldIndex] as Section;
         }
-        else {
+        else if (evt.item.childElementCount === 1) {
             let oldSiblings: any = oldSection ? oldSection.questions : formElements;
-            item = oldSiblings.all.filter((q: Question) => q.id === itemId)[0] as Question;
+            item = oldSiblings.all[evt.oldIndex] as Question;
+        }
+        else { // Error, it should be either 1 or 2 (Question or Section)
+            return true;
         }
         let oldIndex: number = evt.oldIndex;
         let newIndex: number = evt.newIndex;


### PR DESCRIPTION
## Describe your changes
On some specific cases when using drag and drop we were losing the scope of the dragged element.
This scope was needed to get the element's id and thanks to the id to get the object itself.
To fix this we used another way to get this object via the original index and the original container.

## Checklist tests
- Create a form with one section and two questions
- Add two questions inside the section
- Open the organization lightbox
- Take the last element of the form (the second question) and put it in the section
- Take another element inside the section and put it outside
- When bugging, the CSS shift before the element was still large as if the element was in the section instead of being aligned with the other form elements. Now, it should behave correctly.

## Issue ticket number and link
FOR-639 : https://jira.support-ent.fr/browse/FOR-639

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)