### PR TITLE
fix(share): #FOR-516 inform the user that he can't share his form because the users sharing configuration has been exceeded

### DIFF
--- a/common/src/main/java/fr/openent/form/core/enums/I18nKeys.java
+++ b/common/src/main/java/fr/openent/form/core/enums/I18nKeys.java
@@ -5,7 +5,7 @@ public enum I18nKeys {
     COPY("formulaire.copy"),
     OTHER("formulaire.other"),
     END_FORM("formulaire.access.recap"),
-    SHARE_MAX_RECIPIENT_ERROR("formulaire.share.error.max.recipient");
+    MAX_USERS_SHARING_ERROR("formulaire.share.error.max.users");
 
     private final String key;
 

--- a/common/src/main/java/fr/openent/form/core/enums/I18nKeys.java
+++ b/common/src/main/java/fr/openent/form/core/enums/I18nKeys.java
@@ -4,7 +4,8 @@ public enum I18nKeys {
     ARCHIVE_ZIP_NAME("formulaire.archive.zip.name"),
     COPY("formulaire.copy"),
     OTHER("formulaire.other"),
-    END_FORM("formulaire.access.recap");
+    END_FORM("formulaire.access.recap"),
+    SHARE_MAX_RECIPIENT_ERROR("formulaire.share.error.max.recipient");
 
     private final String key;
 

--- a/common/src/main/java/fr/openent/form/helpers/I18nHelper.java
+++ b/common/src/main/java/fr/openent/form/helpers/I18nHelper.java
@@ -6,6 +6,12 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
 public class I18nHelper {
     private static final Logger log = LoggerFactory.getLogger(I18nHelper.class);
 
@@ -18,4 +24,18 @@ public class I18nHelper {
     public static String getI18nValue(I18nKeys i18nKey, String locale) {
         return I18n.getInstance().translate(i18nKey.getKey(), I18n.DEFAULT_DOMAIN, locale);
     }
+
+    public static <T> String getWithParams(I18nKeys key, List<T> params, HttpServerRequest request) {
+        String i18n = getI18nValue(key, request);
+        for(int i = 0; i < params.size(); i ++){
+           i18n = i18n.replace("{" + i + "}", params.get(i).toString());
+        }
+        return i18n;
+    }
+
+    public static <T> String getWithParam(I18nKeys key, T param, HttpServerRequest request){
+        List<T> finalParam = Collections.singletonList(param);
+        return getWithParams(key, finalParam, request);
+    }
+
 }

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/SharingController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/SharingController.java
@@ -1,6 +1,8 @@
 package fr.openent.formulaire.controllers;
 
+import fr.openent.form.core.enums.I18nKeys;
 import fr.openent.form.core.models.ShareObject;
+import fr.openent.form.helpers.I18nHelper;
 import fr.openent.formulaire.security.CustomShareAndOwner;
 import fr.openent.formulaire.service.*;
 import fr.openent.formulaire.service.impl.*;
@@ -31,12 +33,10 @@ import java.util.*;
 
 import static fr.openent.form.core.constants.Constants.MAX_USERS_SHARING;
 import static fr.openent.form.core.constants.EbFields.ACTION;
-import static fr.openent.form.core.constants.EbFields.WORKSPACE_ADDRESS;
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.*;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 import static fr.openent.form.helpers.UtilsHelper.getStringIds;
-import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
 public class SharingController extends ControllerHelper {
     private static final Logger log = LoggerFactory.getLogger(SharingController.class);
@@ -189,9 +189,11 @@ public class SharingController extends ControllerHelper {
 
                         // Check max sharing limit
                         if (responders.size() > MAX_USERS_SHARING) {
-                            log.error("[Formulaire@SharingController::shareResource] " +
-                                    "Share to more than " + MAX_USERS_SHARING + " people is not allowed.");
-                            badRequest(request);
+                            String message = "[Formulaire@SharingController::shareResource] " +
+                                    "Share to more than " + MAX_USERS_SHARING + " people is not allowed.";
+                            log.error(message);
+                            String i18n = I18nHelper.getWithParam(I18nKeys.SHARE_MAX_RECIPIENT_ERROR, MAX_USERS_SHARING, request);
+                            renderInternalError(request, i18n);
                             return;
                         }
 

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/SharingController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/SharingController.java
@@ -192,7 +192,7 @@ public class SharingController extends ControllerHelper {
                             String message = "[Formulaire@SharingController::shareResource] " +
                                     "Share to more than " + MAX_USERS_SHARING + " people is not allowed.";
                             log.error(message);
-                            String i18n = I18nHelper.getWithParam(I18nKeys.SHARE_MAX_RECIPIENT_ERROR, MAX_USERS_SHARING, request);
+                            String i18n = I18nHelper.getWithParam(I18nKeys.MAX_USERS_SHARING_ERROR, MAX_USERS_SHARING, request);
                             renderInternalError(request, i18n);
                             return;
                         }

--- a/formulaire/src/main/resources/i18n/en.json
+++ b/formulaire/src/main/resources/i18n/en.json
@@ -55,7 +55,7 @@
   "formulaire.send": "Envoyer",
   "formulaire.sendTo": "Envoyer à ...",
   "formulaire.share": "Partager",
-  "formulaire.share.error.max.recipient": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
+  "formulaire.share.error.max.users": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
   "formulaire.results": "Résultats",
   "formulaire.remind": "Rappel",
   "formulaire.checkremind": "Suivi",

--- a/formulaire/src/main/resources/i18n/en.json
+++ b/formulaire/src/main/resources/i18n/en.json
@@ -55,6 +55,7 @@
   "formulaire.send": "Envoyer",
   "formulaire.sendTo": "Envoyer à ...",
   "formulaire.share": "Partager",
+  "formulaire.share.error.max.recipient": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
   "formulaire.results": "Résultats",
   "formulaire.remind": "Rappel",
   "formulaire.checkremind": "Suivi",

--- a/formulaire/src/main/resources/i18n/fr.json
+++ b/formulaire/src/main/resources/i18n/fr.json
@@ -55,7 +55,7 @@
   "formulaire.send": "Envoyer",
   "formulaire.sendTo": "Envoyer à ...",
   "formulaire.share": "Partager",
-  "formulaire.share.error.max.recipient": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
+  "formulaire.share.error.max.users": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
   "formulaire.results": "Résultats",
   "formulaire.remind": "Rappel",
   "formulaire.checkremind": "Suivi",

--- a/formulaire/src/main/resources/i18n/fr.json
+++ b/formulaire/src/main/resources/i18n/fr.json
@@ -55,6 +55,7 @@
   "formulaire.send": "Envoyer",
   "formulaire.sendTo": "Envoyer à ...",
   "formulaire.share": "Partager",
+  "formulaire.share.error.max.recipient": "Vous n'êtes pas autorisé à partager à plus de {0} utilisateurs",
   "formulaire.results": "Résultats",
   "formulaire.remind": "Rappel",
   "formulaire.checkremind": "Suivi",

--- a/formulaire/src/main/resources/public/template/lightbox/form-sharing.html
+++ b/formulaire/src/main/resources/public/template/lightbox/form-sharing.html
@@ -1,5 +1,6 @@
 <lightbox show="vm.display.lightbox.sharing" on-close="vm.closeShareFormLightbox()">
-    <share-panel app-prefix="formulaire" resources="vm.forms.selected" auto-close="true"></share-panel>
+    <share-panel app-prefix="formulaire" resources="vm.forms.selected" auto-close="true"
+    on-failure="vm.shareFailure($error)"></share-panel>
 
     <div ng-if="!vm.isCloseConfirmationOpen() && vm.forms.selected[0].is_public">
         <h2><i18n>formulaire.share.link.access</i18n></h2>

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -89,6 +89,7 @@ interface ViewModel {
     duplicateForms() : Promise<void>;
     shareForm() : void;
     closeShareFormLightbox() : void;
+    shareFailure(error: any) : void;
     seeResultsForm() : void;
     isFormOpened(): boolean;
     checkRemind() : Promise<void>;
@@ -352,6 +353,12 @@ export const formsListController = ng.controller('FormsListController', ['$scope
             window.setTimeout(async function () { await vm.openFolder(vm.folder, false); }, 100);
         }
     };
+
+    vm.shareFailure = (error: any) : void => {
+        notify.error(error.responseJSON.error);
+    }
+
+
 
     vm.seeResultsForm = () : void => {
         $scope.redirectTo(`/form/${vm.forms.selected[0].id}/results/1`);

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -89,7 +89,7 @@ interface ViewModel {
     duplicateForms() : Promise<void>;
     shareForm() : void;
     closeShareFormLightbox() : void;
-    shareFailure(error: any) : void;
+    shareFailure(error: JQueryXHR) : void;
     seeResultsForm() : void;
     isFormOpened(): boolean;
     checkRemind() : Promise<void>;
@@ -354,7 +354,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
         }
     };
 
-    vm.shareFailure = (error: any) : void => {
+    vm.shareFailure = (error: JQueryXHR) : void => {
         notify.error(error.responseJSON.error);
     }
 


### PR DESCRIPTION
## Describe your changes
We add a custom message in back sharing controller to send it back to the directive.
As this directive **(share-panel)** is in infra-front, we handled a new case in that directive by passing the error in a new function in the catch section like this :
                   **$attributes.onFailure ? $scope.onFailure( {'$error' : e} ) : notify.error('share.notify.error');**
Then, we passed this function onFailure directly to the html tag of the directive to get the error back in our module and send a **notify.error** with it.

Check the infra-front PR for more information :
https://github.com/CGI-OPEN-ENT-NG/infra-front/pull/8
## Checklist tests
In ent-core.json, set the "max-users-sharing" to 0 (in formulaire config), then try to share a form to someone. A warning must appear.
## Issue ticket number and link
[FOR-516](https://jira.support-ent.fr/browse/FOR-516)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)