### PR TITLE
fix(sharing): [#FOR-636] improve sharing rights system

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/ShareRights.java
+++ b/common/src/main/java/fr/openent/form/core/constants/ShareRights.java
@@ -1,10 +1,12 @@
 package fr.openent.form.core.constants;
 
 public class ShareRights {
+    public static final String READ_RESOURCE_RIGHT = "formulaire.read";
     public static final String CONTRIB_RESOURCE_RIGHT = "formulaire.contrib";
     public static final String MANAGER_RESOURCE_RIGHT = "formulaire.manager";
     public static final String RESPONDER_RESOURCE_RIGHT = "formulaire.comment";
 
+    public static final String READ_RESOURCE_BEHAVIOUR = "fr-openent-formulaire-controllers-FormController|initReadResourceRight";
     public static final String CONTRIB_RESOURCE_BEHAVIOUR = "fr-openent-formulaire-controllers-FormController|initContribResourceRight";
     public static final String MANAGER_RESOURCE_BEHAVIOUR = "fr-openent-formulaire-controllers-FormController|initManagerResourceRight";
     public static final String RESPONDER_RESOURCE_BEHAVIOUR = "fr-openent-formulaire-controllers-FormController|initResponderResourceRight";

--- a/common/src/main/java/fr/openent/form/core/models/ShareObject.java
+++ b/common/src/main/java/fr/openent/form/core/models/ShareObject.java
@@ -80,27 +80,20 @@ public class ShareObject implements Model<ShareObject> {
         return new ShareObject(shareObject);
     }
 
-    public ShareObject addCommonRights() {
-        JsonArray commonRights = RightsHelper.getCommonRights();
-
+    public void addCommonRights(JsonArray commonRights) {
         addCommonRightByField(USERS, commonRights);
         addCommonRightByField(GROUPS, commonRights);
         addCommonRightByField(BOOKMARKS, commonRights);
-
-        return this;
     }
 
     private void addCommonRightByField(String field, JsonArray commonRights) {
         JsonObject rightsById = getJsonObjectFieldInfos(field);
 
-        if (!rightsById.isEmpty()) {
-            List<String> ids = new ArrayList<>(rightsById.fieldNames());
-
-            for (String id : ids) {
-                JsonArray rights = rightsById.getJsonArray(id);
-                boolean shouldAddCommonRight = rights.stream().anyMatch(right -> RightsHelper.hasSharingRight((String) right));
-                if (shouldAddCommonRight) rights.addAll(commonRights);
-            }
+        if (rightsById != null && !rightsById.isEmpty()) {
+            rightsById.fieldNames().stream()
+                .map(rightsById::getJsonArray)
+                .filter(rights -> rights.stream().anyMatch(right -> RightsHelper.hasSharingRight((String) right)))
+                .forEach(rights -> rights.addAll(commonRights));
         }
     }
 

--- a/common/src/main/java/fr/openent/form/helpers/RightsHelper.java
+++ b/common/src/main/java/fr/openent/form/helpers/RightsHelper.java
@@ -1,7 +1,6 @@
 package fr.openent.form.helpers;
 
 import fr.openent.form.core.constants.ShareRights;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -9,11 +8,6 @@ public class RightsHelper {
     private static final Logger log = LoggerFactory.getLogger(RightsHelper.class);
 
     private RightsHelper() {}
-
-    public static JsonArray getCommonRights() {
-        return new JsonArray()
-                .add("fr-openent-formulaire-controllers-FormController|get");
-    }
 
     public static boolean hasSharingRight(String right) {
         return right.equals(ShareRights.RESPONDER_RESOURCE_BEHAVIOUR) ||

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/DistributionController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/DistributionController.java
@@ -1,6 +1,5 @@
 package fr.openent.formulaire.controllers;
 
-import fr.openent.formulaire.security.AccessRight;
 import fr.openent.formulaire.security.CreationRight;
 import fr.openent.formulaire.security.ResponseRight;
 import fr.openent.formulaire.security.CustomShareAndOwner;
@@ -93,8 +92,8 @@ public class DistributionController extends ControllerHelper {
 
     @Get("/distributions/forms/:formId/listMine")
     @ApiDoc("List all the distributions for a specific form sent to me")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void listByFormAndResponder(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         UserUtils.getUserInfos(eb, request, user -> {

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -91,6 +91,10 @@ public class FormController extends ControllerHelper {
 
     // Init sharing rights
 
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
+    public void initReadResourceRight(final HttpServerRequest request) {
+    }
+
     @SecuredAction(value = CONTRIB_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void initContribResourceRight(final HttpServerRequest request) {
     }
@@ -174,7 +178,7 @@ public class FormController extends ControllerHelper {
     @Get("/forms/:formId")
     @ApiDoc("Get a specific form by id")
     @ResourceFilter(CustomShareAndOwner.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void get(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         UserUtils.getUserInfos(eb, request, user -> {
@@ -1055,8 +1059,8 @@ public class FormController extends ControllerHelper {
 
     @Get("/forms/:formId/rights")
     @ApiDoc("Get my rights for a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void getMyFormRights(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         UserUtils.getUserInfos(eb, request, user -> {

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
@@ -4,7 +4,6 @@ import fr.openent.form.core.models.FormElement;
 import fr.openent.form.core.models.Question;
 import fr.openent.form.core.models.QuestionChoice;
 import fr.openent.form.helpers.UtilsHelper;
-import fr.openent.formulaire.security.AccessRight;
 import fr.openent.formulaire.security.CustomShareAndOwner;
 import fr.openent.formulaire.service.FormElementService;
 import fr.openent.formulaire.service.QuestionChoiceService;
@@ -30,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
+import static fr.openent.form.core.constants.ShareRights.READ_RESOURCE_RIGHT;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
 
@@ -47,8 +47,8 @@ public class FormElementController extends ControllerHelper {
 
     @Get("/forms/:formId/elements/count")
     @ApiDoc("Count the number of form elements in a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void countFormElements(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         formElementService.countFormElements(formId, defaultResponseHandler(request));
@@ -56,8 +56,8 @@ public class FormElementController extends ControllerHelper {
 
     @Get("/forms/:formId/elements/:position")
     @ApiDoc("Get a specific form element by position in a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void getByPosition(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         String position = request.getParam(POSITION);

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionChoiceController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionChoiceController.java
@@ -22,6 +22,7 @@ import org.entcore.common.http.filter.ResourceFilter;
 
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
+import static fr.openent.form.core.constants.ShareRights.READ_RESOURCE_RIGHT;
 import static fr.openent.form.core.enums.ApiVersions.*;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 
@@ -36,8 +37,8 @@ public class QuestionChoiceController extends ControllerHelper {
 
     @Get("/questions/:questionId/choices")
     @ApiDoc("List all the choices of a specific question")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void list(HttpServerRequest request) {
         String questionId = request.getParam(PARAM_QUESTION_ID);
         String apiVersion = RequestUtils.acceptVersion(request);

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/QuestionController.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static fr.openent.form.core.constants.Constants.CONDITIONAL_QUESTIONS;
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
+import static fr.openent.form.core.constants.ShareRights.READ_RESOURCE_RIGHT;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 import static fr.openent.form.helpers.UtilsHelper.getByProp;
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
@@ -51,15 +52,15 @@ public class QuestionController extends ControllerHelper {
 
     @Get("/forms/:formId/questions")
     @ApiDoc("List all the questions of a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void listForForm(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
 
         questionService.listForForm(formId, listQuestionsEvt -> {
             if (listQuestionsEvt.isLeft()) {
-                log.error("[Formulaire@listForFrom] Fail to list questions for form with id : " + formId);
-                renderInternalError(request, listQuestionsEvt);
+                log.error("[Formulaire@QuestionController::listForForm] Fail to list questions for form with id " + formId + " : " + listQuestionsEvt);
+                renderError(request);
                 return;
             }
             JsonArray questions = listQuestionsEvt.right().getValue();
@@ -71,8 +72,8 @@ public class QuestionController extends ControllerHelper {
 
     @Get("/sections/:sectionId/questions")
     @ApiDoc("List all the questions of a specific section")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void listForSection(HttpServerRequest request) {
         String sectionId = request.getParam(PARAM_SECTION_ID);
 
@@ -92,8 +93,8 @@ public class QuestionController extends ControllerHelper {
 
     @Get("/forms/:formId/questions/all")
     @ApiDoc("List all the questions of a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void listForFormAndSection(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
 

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseFileController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/ResponseFileController.java
@@ -3,7 +3,6 @@ package fr.openent.formulaire.controllers;
 import fr.openent.form.core.enums.I18nKeys;
 import fr.openent.form.helpers.I18nHelper;
 import fr.openent.formulaire.helpers.folder_exporter.FolderExporterZip;
-import fr.openent.formulaire.security.AccessRight;
 import fr.openent.formulaire.security.CustomShareAndOwner;
 import fr.openent.formulaire.service.ResponseFileService;
 import fr.openent.formulaire.service.impl.DefaultResponseFileService;
@@ -26,8 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static fr.openent.form.core.constants.Fields.*;
-import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
-import static fr.openent.form.core.constants.ShareRights.RESPONDER_RESOURCE_RIGHT;
+import static fr.openent.form.core.constants.ShareRights.*;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
@@ -48,8 +46,8 @@ public class ResponseFileController extends ControllerHelper {
 
     @Get("/responses/:responseId/files/all")
     @ApiDoc("List all files of a specific response")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void list(HttpServerRequest request) {
         String responseId = request.getParam(PARAM_RESPONSE_ID);
         responseFileService.list(responseId, arrayResponseHandler(request));
@@ -57,8 +55,8 @@ public class ResponseFileController extends ControllerHelper {
 
     @Get("/questions/:questionId/files/all")
     @ApiDoc("List all files of all responses to a specific question")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void listByQuestion(HttpServerRequest request) {
         String questionId = request.getParam(PARAM_QUESTION_ID);
         responseFileService.listByQuestion(questionId, arrayResponseHandler(request));

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/SectionController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/SectionController.java
@@ -1,10 +1,8 @@
 package fr.openent.formulaire.controllers;
 
 import fr.openent.form.core.models.Section;
-import fr.openent.form.helpers.FutureHelper;
 import fr.openent.form.helpers.UtilsHelper;
 import fr.openent.formulaire.helpers.DataChecker;
-import fr.openent.formulaire.security.AccessRight;
 import fr.openent.formulaire.security.CustomShareAndOwner;
 import fr.openent.formulaire.service.DistributionService;
 import fr.openent.formulaire.service.FormElementService;
@@ -19,7 +17,6 @@ import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.logging.Logger;
@@ -27,12 +24,12 @@ import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.http.filter.ResourceFilter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static fr.openent.form.core.constants.Fields.*;
 import static fr.openent.form.core.constants.ShareRights.CONTRIB_RESOURCE_RIGHT;
+import static fr.openent.form.core.constants.ShareRights.READ_RESOURCE_RIGHT;
 import static fr.openent.form.helpers.RenderHelper.renderInternalError;
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
@@ -54,8 +51,8 @@ public class SectionController extends ControllerHelper {
 
     @Get("/forms/:formId/sections")
     @ApiDoc("List all the sections of a specific form")
-    @ResourceFilter(AccessRight.class)
-    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(CustomShareAndOwner.class)
+    @SecuredAction(value = READ_RESOURCE_RIGHT, type = ActionType.RESOURCE)
     public void list(HttpServerRequest request) {
         String formId = request.getParam(PARAM_FORM_ID);
         sectionService.list(formId, arrayResponseHandler(request));

--- a/formulaire/src/main/java/fr/openent/formulaire/security/CustomShareAndOwner.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/security/CustomShareAndOwner.java
@@ -84,29 +84,31 @@ public class CustomShareAndOwner implements ResourcesProvider {
 
 
     private String getKeyByBinding(Binding binding) {
-        if (isGetForm(binding) || isCountDistribution(binding) || isGetByFormResponderAndStatusDistribution(binding) ||
-                isUpdateForm(binding) || isDeleteForm(binding) || isSendReminderForm(binding) || isUpdateFormElement(binding) ||
-                isCreateQuestion(binding) || isListByFormResponse(binding) || isDeleteResponse(binding) ||
-                isExportResponse(binding) || isCreateSection(binding) || isUpdateSection(binding) || isUpdateQuestion(binding)) {
+        if (isListByFormAndResponderDistribution(binding) || isCountDistribution(binding) || isGetByFormResponderAndStatusDistribution(binding) ||
+                isGetForm(binding) || isUpdateForm(binding) || isDeleteForm(binding) || isSendReminderForm(binding) ||
+                isGetMyFormRightsForm(binding) || isCountFormElements(binding) || isGetByPositionFormElement(binding) ||
+                isUpdateFormElement(binding) || isListForFormQuestion(binding) || isListForFormAndSectionQuestion(binding) ||
+                isCreateQuestion(binding) || isListByFormResponse(binding) || isDeleteResponse(binding) || isExportResponse(binding) ||
+                isListSection(binding) || isCreateSection(binding) || isUpdateSection(binding) || isUpdateQuestion(binding)) {
             return PARAM_FORM_ID;
         }
         else if (isGetDistribution(binding) || isAddDistribution(binding) || isUpdateDistribution(binding) ||
-                isDuplicateWithResponsesDistribution(binding) || isReplaceDistribution(binding) ||
-                isDeleteDistribution(binding) || isListByDistributionResponse(binding) || isDeleteByQuestionResponse(binding)) {
+                isDuplicateWithResponsesDistribution(binding) || isReplaceDistribution(binding) || isDeleteDistribution(binding) ||
+                isListByDistributionResponse(binding) || isDeleteByQuestionResponse(binding)) {
             return PARAM_DISTRIBUTION_ID;
         }
-        else if (isGetSection(binding) || isDeleteSection(binding)) {
+        else if (isListForSectionQuestion(binding) || isGetSection(binding) || isDeleteSection(binding)) {
             return PARAM_SECTION_ID;
         }
-        else if (isListMineByDistributionResponse(binding) || isCreateQuestionChoice(binding) || isGetQuestion(binding) ||
-                isDeleteQuestion(binding) || isListResponse(binding) || isCreateResponse(binding) ||
-                isZipAndDownloadResponseFile(binding)) {
+        else if (isListMineByDistributionResponse(binding) || isListQuestionChoice(binding) || isCreateQuestionChoice(binding) ||
+                isGetQuestion(binding) || isDeleteQuestion(binding) || isListResponse(binding) || isCreateResponse(binding) ||
+                isListByQuestionResponseFile(binding) || isZipAndDownloadResponseFile(binding)) {
             return PARAM_QUESTION_ID;
         }
         else if (isUpdateQuestionChoice(binding) || isDeleteQuestionChoice(binding)) {
             return PARAM_CHOICE_ID;
         }
-        else if (isUpdateResponse(binding) || isUploadResponseFile(binding) || isDeleteAllResponseFile(binding)) {
+        else if (isUpdateResponse(binding) || isListResponseFile(binding) || isUploadResponseFile(binding) || isDeleteAllResponseFile(binding)) {
             return PARAM_RESPONSE_ID;
         }
         else if (isGetResponseFile(binding) || isDownloadResponseFile(binding)) {
@@ -122,6 +124,10 @@ public class CustomShareAndOwner implements ResourcesProvider {
     }
 
     // Distribution
+    private boolean isListByFormAndResponderDistribution(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.DistributionController|listByFormAndResponder");
+    }
+
     private boolean isCountDistribution(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.DistributionController|count");
     }
@@ -171,12 +177,28 @@ public class CustomShareAndOwner implements ResourcesProvider {
         return bindingIsThatMethod(binding, HttpMethod.POST, "fr.openent.formulaire.controllers.FormController|sendReminder");
     }
 
+    private boolean isGetMyFormRightsForm(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.FormController|getMyFormRights");
+    }
+
     // FormElement
+    private boolean isCountFormElements(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.FormElementController|countFormElements");
+    }
+
+    private boolean isGetByPositionFormElement(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.FormElementController|getByPosition");
+    }
+
     private boolean isUpdateFormElement(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.PUT, "fr.openent.formulaire.controllers.FormElementController|update");
     }
 
     // QuestionChoice
+    private boolean isListQuestionChoice(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.QuestionChoiceController|list");
+    }
+
     private boolean isCreateQuestionChoice(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.POST, "fr.openent.formulaire.controllers.QuestionChoiceController|create");
     }
@@ -190,6 +212,18 @@ public class CustomShareAndOwner implements ResourcesProvider {
     }
 
     // Question
+    private boolean isListForFormQuestion(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.QuestionController|listForForm");
+    }
+
+    private boolean isListForSectionQuestion(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.QuestionController|listForSection");
+    }
+
+    private boolean isListForFormAndSectionQuestion(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.QuestionController|listForFormAndSection");
+    }
+
     private boolean isGetQuestion(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.QuestionController|get");
     }
@@ -244,6 +278,14 @@ public class CustomShareAndOwner implements ResourcesProvider {
     }
 
     // ResponseFile
+    private boolean isListResponseFile(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.ResponseFileController|list");
+    }
+
+    private boolean isListByQuestionResponseFile(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.ResponseFileController|listByQuestion");
+    }
+
     private boolean isGetResponseFile(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.ResponseFileController|get");
     }
@@ -265,6 +307,10 @@ public class CustomShareAndOwner implements ResourcesProvider {
     }
 
     // Section
+    private boolean isListSection(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.SectionController|list");
+    }
+
     private boolean isGetSection(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.GET, "fr.openent.formulaire.controllers.SectionController|get");
     }

--- a/formulaire/src/main/resources/public/ts/behaviours.ts
+++ b/formulaire/src/main/resources/public/ts/behaviours.ts
@@ -3,6 +3,9 @@ import {formService} from "@common/services";
 
 const rights = {
     resources: {
+        read: {
+            right: "fr-openent-formulaire-controllers-FormController|initReadResourceRight"
+        },
         contrib: {
             right: "fr-openent-formulaire-controllers-FormController|initContribResourceRight"
         },
@@ -42,6 +45,6 @@ Behaviours.register('formulaire', {
     },
 
     resourceRights: function () {
-        return ['contrib', 'manager', 'comment'];
+        return ['read', 'contrib', 'manager', 'comment'];
     }
 });

--- a/formulaire/src/main/resources/sql/027-add-sharing-rights.sql
+++ b/formulaire/src/main/resources/sql/027-add-sharing-rights.sql
@@ -1,0 +1,121 @@
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initContribResourceRight'
+       OR action = 'fr-openent-formulaire-controllers-FormController|initResponderResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-DistributionController|listByFormAndResponder'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-FormController|get'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-FormController|getMyFormRights'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-FormElementController|countFormElements'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-FormElementController|getByPosition'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-SectionController|list'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-QuestionController|listForForm'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-QuestionController|listForSection'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-QuestionController|listForFormAndSection'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-QuestionChoiceController|list'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-ResponseFileController|list'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-ResponseFileController|listByQuestion'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initReadResourceRight'
+) ON CONFLICT DO NOTHING;
+
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|initManagerResourceRight' WHERE action = 'fr.openent.formulaire.controllers.FormController|initManagerResourceRight';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|delete' WHERE action = 'fr.openent.formulaire.controllers.FormController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|initResponderResourceRight' WHERE action = 'fr.openent.formulaire.controllers.FormController|initResponderResourceRight';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|update' WHERE action = 'fr.openent.formulaire.controllers.FormController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|sendReminder' WHERE action = 'fr.openent.formulaire.controllers.FormController|sendReminder';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormController|initContribResourceRight' WHERE action = 'fr.openent.formulaire.controllers.FormController|initContribResourceRight';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SharingController|shareSubmit' WHERE action = 'fr.openent.formulaire.controllers.SharingController|shareSubmit';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SharingController|shareResource' WHERE action = 'fr.openent.formulaire.controllers.SharingController|shareResource';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SharingController|shareJson' WHERE action = 'fr.openent.formulaire.controllers.SharingController|shareJson';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-FormElementController|update' WHERE action = 'fr.openent.formulaire.controllers.FormElementController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SectionController|update' WHERE action = 'fr.openent.formulaire.controllers.SectionController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SectionController|get' WHERE action = 'fr.openent.formulaire.controllers.SectionController|get';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SectionController|delete' WHERE action = 'fr.openent.formulaire.controllers.SectionController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-SectionController|create' WHERE action = 'fr.openent.formulaire.controllers.SectionController|create';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionController|update' WHERE action = 'fr.openent.formulaire.controllers.QuestionController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionController|get' WHERE action = 'fr.openent.formulaire.controllers.QuestionController|get';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionController|delete' WHERE action = 'fr.openent.formulaire.controllers.QuestionController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionController|create' WHERE action = 'fr.openent.formulaire.controllers.QuestionController|create';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionChoiceController|update' WHERE action = 'fr.openent.formulaire.controllers.QuestionChoiceController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionChoiceController|delete' WHERE action = 'fr.openent.formulaire.controllers.QuestionChoiceController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-QuestionChoiceController|create' WHERE action = 'fr.openent.formulaire.controllers.QuestionChoiceController|create';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|delete' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|update' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|replace' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|replace';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|get' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|get';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|duplicateWithResponses' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|duplicateWithResponses';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|add' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|add';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|count' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|count';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-DistributionController|count' WHERE action = 'fr.openent.formulaire.controllers.DistributionController|count';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|list' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|list';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|update' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|update';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|listMineByDistribution' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|listMineByDistribution';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|listByDistribution' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|listByDistribution';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|deleteByQuestionAndDistribution' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|deleteByQuestionAndDistribution';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|delete' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|delete';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|create' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|create';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseController|export' WHERE action = 'fr.openent.formulaire.controllers.ResponseController|export';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseFileController|zipAndDownload' WHERE action = 'fr.openent.formulaire.controllers.ResponseFileController|zipAndDownload';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseFileController|get' WHERE action = 'fr.openent.formulaire.controllers.ResponseFileController|get';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseFileController|download' WHERE action = 'fr.openent.formulaire.controllers.ResponseFileController|download';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseFileController|upload' WHERE action = 'fr.openent.formulaire.controllers.ResponseFileController|upload';
+UPDATE formulaire.form_shares SET action = 'fr-openent-formulaire-controllers-ResponseFileController|deleteAll' WHERE action = 'fr.openent.formulaire.controllers.ResponseFileController|deleteAll';


### PR DESCRIPTION
## Describe your changes
We improved API security. Before, some API routes were secured by an AccessRight.class file only checking if the connected user had a workflow right to access the Formulaire mod.
That means anyone acessing Formulaire could call these API and get the responses.
We changed that by using the sharing security system : now, you need to have at least one sharing right on the form to call these API and get the infos.

To sum up :
- Before if acessing Formulaire you could get many infos of forms not related to you at all
- Now you need these forms to be shared to you as contributor, manager or responder at least to get these infos

All the refacto/improvement/modeling will be in the following ticket : https://jira.support-ent.fr/browse/FOR-692

## Checklist tests

## Issue ticket number and link
FOR-636 : https://jira.support-ent.fr/browse/FOR-636

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)