### PR TITLE
 fix(css): #FOR-708 change entcore-css-lib import and keep only variable file

### DIFF
--- a/formulaire/src/main/resources/public/sass/index.scss
+++ b/formulaire/src/main/resources/public/sass/index.scss
@@ -1,5 +1,5 @@
 /* ENTCORE CSS LIB */
-@import "./entcore-css-lib/scss/index.scss";
+@import "./entcore-css-lib/scss/variables-css-lib";
 
 @import "global/formulaire";
 


### PR DESCRIPTION
## Describe your changes
There was a bad height of navbar because of general import of all entcore-css-lib files.
Indeed, it forced the navbar class to have a height of 40px.
By removing this general import and keep only the file we need to import, we get rid of this behaviour.
## Checklist tests

## Issue ticket number and link
[FOR-708](https://jira.support-ent.fr/browse/FOR-708)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)