### PR TITLE
fix(image): [#FOR-567] fix image proportions in form prop view

### DIFF
--- a/formulaire/src/main/resources/public/sass/global/components/_prop-form.scss
+++ b/formulaire/src/main/resources/public/sass/global/components/_prop-form.scss
@@ -9,14 +9,10 @@
     @media screen and (max-width: $formulaire-screen-laptop) { width: 100%; }
 
     .domino {
-      .picture {
-        &:hover {
-          cursor: pointer;
-        }
-
-        image-select {
-          width: 100%;
-        }
+      .image-container {
+        display: flex;
+        align-items: center;
+        position: relative;
       }
 
       .data {

--- a/formulaire/src/main/resources/public/template/containers/prop-form.html
+++ b/formulaire/src/main/resources/public/template/containers/prop-form.html
@@ -14,8 +14,9 @@
     <div class="prop-form dominos" guard-root>
         <div class="item">
             <div class="domino">
-                <div class="three cell picture" ng-class="{'empty': !vm.form.picture}">
-                    <image-select ng-model="vm.form.picture"
+                <div class="three image-container" ng-class="{'empty': !vm.form.picture}">
+                    <image-select class="initialFloat cell"
+                                  ng-model="vm.form.picture"
                                   ng-change="vm.getImage()"
                                   default="/img/illustrations/image-default.svg">
                     </image-select>


### PR DESCRIPTION
## Describe your changes
On the Property view of a form, the area for adding an image was stretch and it was ugly.
We fiwed it to keep the proportions of the image.

## Checklist tests

## Issue ticket number and link
FOR-567 : https://jira.support-ent.fr/browse/FOR-567

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)