### PR TITLE
fix(buttons): #FOR-595 block user from spamming buttons

### DIFF
--- a/formulaire-public/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire-public/src/main/resources/public/template/containers/respond-question.html
@@ -50,7 +50,7 @@
             <div class="buttons">
                 <button class="cell" ng-if="vm.formElement.position <= 1" ng-disabled="true"><i18n>formulaire.public.prev</i18n></button>
                 <button class="cell cancel" reset-guard="vm.prev()" ng-if="vm.formElement.position > 1"><i18n>formulaire.public.prev</i18n></button>
-                <button class="cell" reset-guard="vm.next()"><i18n>formulaire.public.next</i18n></button>
+                <button class="cell" reset-guard="vm.next()" ng-disabled="vm.isProcessing"><i18n>formulaire.public.next</i18n></button>
             </div>
         </div>
     </div>

--- a/formulaire-public/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire-public/src/main/resources/public/template/containers/respond-question.html
@@ -49,7 +49,8 @@
             <!-- Bottom page buttons -->
             <div class="buttons">
                 <button class="cell" ng-if="vm.formElement.position <= 1" ng-disabled="true"><i18n>formulaire.public.prev</i18n></button>
-                <button class="cell cancel" reset-guard="vm.prev()" ng-if="vm.formElement.position > 1"><i18n>formulaire.public.prev</i18n></button>
+                <button class="cell cancel" reset-guard="vm.prev()" ng-disabled="vm.isProcessing"
+                        ng-if="vm.formElement.position > 1"><i18n>formulaire.public.prev</i18n></button>
                 <button class="cell" reset-guard="vm.next()" ng-disabled="vm.isProcessing"><i18n>formulaire.public.next</i18n></button>
             </div>
         </div>

--- a/formulaire-public/src/main/resources/public/template/lightbox/responses-confirm-sending.html
+++ b/formulaire-public/src/main/resources/public/template/lightbox/responses-confirm-sending.html
@@ -8,6 +8,6 @@
     </div>
     <div class="action-buttons">
         <button class="cell cancel" ng-click="vm.display.lightbox.sending = false;"><i18n>formulaire.public.cancel</i18n></button>
-        <button class="cell" ng-click="vm.doSend()"><i18n>formulaire.public.confirm</i18n></button>
+        <button class="cell" ng-click="vm.doSend()" ng-disabled="vm.isProcessing"><i18n>formulaire.public.confirm</i18n></button>
     </div>
 </lightbox>

--- a/formulaire-public/src/main/resources/public/ts/controllers/captcha.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/captcha.ts
@@ -16,6 +16,7 @@ interface ViewModel {
             sending: boolean
         }
     };
+    isProcessing: boolean;
 
     $onInit() : Promise<void>;
     send() : void;
@@ -65,6 +66,7 @@ export const captchaController = ng.controller('CaptchaController', ['$scope',
     vm.doSend = async () : Promise<void> => {
         let distributionData = await responseService.sendResponses(vm.formKey, vm.distributionKey, vm.responseCaptcha, vm.responses);
         let distribution = Mix.castAs(Question, distributionData);
+        vm.isProcessing = true;
 
         template.close('lightbox');
         vm.display.lightbox.sending = false;
@@ -80,6 +82,7 @@ export const captchaController = ng.controller('CaptchaController', ['$scope',
                 template.open('main', 'containers/end/thanks');
             }, 1000);
         }
+        vm.isProcessing = false;
     };
 
     // Utils

--- a/formulaire-public/src/main/resources/public/ts/controllers/captcha.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/captcha.ts
@@ -64,9 +64,9 @@ export const captchaController = ng.controller('CaptchaController', ['$scope',
     };
 
     vm.doSend = async () : Promise<void> => {
+        vm.isProcessing = true;
         let distributionData = await responseService.sendResponses(vm.formKey, vm.distributionKey, vm.responseCaptcha, vm.responses);
         let distribution = Mix.castAs(Question, distributionData);
-        vm.isProcessing = true;
 
         template.close('lightbox');
         vm.display.lightbox.sending = false;

--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -53,6 +53,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 	}
 
 	vm.prev = () : void => {
+		vm.isProcessing = true;
 		formatResponses();
 		let prevPosition = vm.historicPosition[vm.historicPosition.length - 2];
 		if (prevPosition > 0) {
@@ -61,6 +62,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			vm.historicPosition.pop();
 			goToFormElement(isCursorAgain);
 		}
+		vm.isProcessing = false;
 	};
 
 	vm.next = () : void => {

--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -23,6 +23,7 @@ interface ViewModel {
 	form: Form;
 	nbFormElements: number;
 	historicPosition: number[];
+	isProcessing: boolean;
 
 	$onInit(): Promise<void>;
 	prev() : void;
@@ -63,6 +64,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 	};
 
 	vm.next = () : void => {
+		vm.isProcessing = true;
 		formatResponses();
 		let nextPosition = getNextPositionIfValid();
 		if (nextPosition && nextPosition <= vm.nbFormElements) {
@@ -75,6 +77,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			updateStorage();
 			template.open('main', 'containers/recap');
 		}
+		vm.isProcessing = false;
 	};
 
 	vm.getHtmlDescription = (description: string) : string => {

--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -63,6 +63,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			goToFormElement(isCursorAgain);
 		}
 		vm.isProcessing = false;
+		$scope.safeApply();
 	};
 
 	vm.next = () : void => {
@@ -73,13 +74,15 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			let isCursorAgain: boolean = vm.formElement.isSameQuestionTypeOfType(vm.formElements.all[nextPosition - 1], Types.CURSOR);
 			vm.formElement = vm.formElements.all[nextPosition - 1];
 			vm.historicPosition.push(vm.formElement.position);
+			vm.isProcessing = false;
 			goToFormElement(isCursorAgain);
 		}
 		else if (nextPosition !== undefined) {
 			updateStorage();
+			vm.isProcessing = false;
 			template.open('main', 'containers/recap');
 		}
-		vm.isProcessing = false;
+		$scope.safeApply();
 	};
 
 	vm.getHtmlDescription = (description: string) : string => {

--- a/formulaire/src/main/resources/public/template/components/toasters/toaster-forms-list.html
+++ b/formulaire/src/main/resources/public/template/components/toasters/toaster-forms-list.html
@@ -8,7 +8,7 @@
             <button ng-click="vm.openPropertiesForm()" class="cell" ng-show="vm.forms.selected.length === 1">
                 <i18n>formulaire.properties</i18n>
             </button>
-            <button ng-click="vm.duplicateForms()" class="cell">
+            <button ng-click="vm.duplicateForms()" ng-disabled="vm.isProcessing" class="cell">
                 <i18n>formulaire.duplicate</i18n>
             </button>
             <button ng-click="vm.moveItems()" class="cell" ng-show="vm.folder.id != vm.folders.sharedFormsFolder.id">

--- a/formulaire/src/main/resources/public/template/containers/edit-form.html
+++ b/formulaire/src/main/resources/public/template/containers/edit-form.html
@@ -26,7 +26,7 @@
                         <i18n>formulaire.organize</i18n>
                     </button>
                     <button class="cell cancel dontSave" ng-click="vm.goPreview()" ng-show="vm.formElements.all.length >= 1"><i18n>formulaire.preview</i18n></button>
-                    <button class="cell" ng-click="vm.saveAll(true)"><i18n>formulaire.save</i18n></button>
+                    <button class="cell" ng-click="vm.saveAll(true)" ng-disabled="vm.isProcessing"><i18n>formulaire.save</i18n></button>
                 </div>
             </section>
 
@@ -84,7 +84,7 @@
             <div class="buttons">
                 <div class="flexend nine zero-mobile">
                     <button class="cell" id="createNewEltConfirm1" ng-class="{blueButton: vm.form.nb_responses <= 0}"
-                            ng-click="vm.createNewElement()" ng-disabled="vm.form.nb_responses > 0">
+                            ng-click="vm.createNewElement()" ng-disabled="vm.form.nb_responses > 0 || vm.display.lightbox.newElement">
                         <i18n>formulaire.add.element</i18n>
                     </button>
                 </div>

--- a/formulaire/src/main/resources/public/template/containers/prop-form.html
+++ b/formulaire/src/main/resources/public/template/containers/prop-form.html
@@ -134,7 +134,7 @@
                             </div>
                             <div class="action-buttons">
                                 <button class="cell cancel" ng-click="redirectTo('/list/mine')"><i18n>formulaire.cancel</i18n></button>
-                                <button class="cell" reset-guard="vm.saveGuard()" ng-disabled="!vm.form.title || !vm.checkIntervalDates()"><i18n>formulaire.save</i18n></button>
+                                <button class="cell" reset-guard="vm.saveGuard()" ng-disabled="!vm.form.title || !vm.checkIntervalDates() || vm.isProcessing"><i18n>formulaire.save</i18n></button>
                             </div>
                         </div>
                     </div>

--- a/formulaire/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire/src/main/resources/public/template/containers/respond-question.html
@@ -61,8 +61,8 @@
             <!-- Bottom page buttons -->
             <div class="buttons">
                 <button class="cell" ng-if="vm.formElement.position <= 1" ng-disabled="true"><i18n>formulaire.prev</i18n></button>
-                <button class="cell cancel" reset-guard="vm.prevGuard()" ng-if="vm.formElement.position > 1"><i18n>formulaire.prev</i18n></button>
-                <button class="cell" reset-guard="vm.nextGuard()"><i18n>formulaire.next</i18n></button>
+                <button class="cell cancel" reset-guard="vm.prevGuard()" ng-if="vm.formElement.position > 1" ng-disabled="vm.isProcessing"><i18n>formulaire.prev</i18n></button>
+                <button class="cell" reset-guard="vm.nextGuard()" ng-disabled="vm.isProcessing"><i18n>formulaire.next</i18n></button>
             </div>
         </div>
     </div>

--- a/formulaire/src/main/resources/public/template/containers/results-form.html
+++ b/formulaire/src/main/resources/public/template/containers/results-form.html
@@ -63,7 +63,7 @@
                     </option>
                 </select>
             </div>
-            <button class="cell" ng-click="vm.next()" ng-disabled="vm.last" ng-disabled="vm.isProcessing">
+            <button class="cell" ng-click="vm.next()" ng-disabled="vm.last || vm.isProcessing">
                 <i18n class="zero-mobile">formulaire.next</i18n>
                 <i class="i-chevron-right zero-desktop"></i>
             </button>

--- a/formulaire/src/main/resources/public/template/containers/results-form.html
+++ b/formulaire/src/main/resources/public/template/containers/results-form.html
@@ -63,7 +63,7 @@
                     </option>
                 </select>
             </div>
-            <button class="cell" ng-click="vm.next()" ng-disabled="vm.last">
+            <button class="cell" ng-click="vm.next()" ng-disabled="vm.last" ng-disabled="vm.isProcessing">
                 <i18n class="zero-mobile">formulaire.next</i18n>
                 <i class="i-chevron-right zero-desktop"></i>
             </button>

--- a/formulaire/src/main/resources/public/template/containers/results-form.html
+++ b/formulaire/src/main/resources/public/template/containers/results-form.html
@@ -50,7 +50,7 @@
 
         <!-- Navigation buttons -->
         <div class="buttons">
-            <button class="cell" ng-click="vm.prev()" ng-disabled="vm.formElement.position == 1">
+            <button class="cell" ng-click="vm.prev()" ng-disabled="vm.formElement.position == 1 || vm.isProcessing">
                 <i18n class="zero-mobile">formulaire.prev</i18n>
                 <i class="i-chevron-left zero-desktop"></i>
             </button>

--- a/formulaire/src/main/resources/public/template/lightbox/form-confirm-archive.html
+++ b/formulaire/src/main/resources/public/template/lightbox/form-confirm-archive.html
@@ -21,6 +21,6 @@
     </table>
     <div class="action-buttons">
         <button class="cell cancel" ng-click="vm.display.lightbox.archive = false"><i18n>formulaire.cancel</i18n></button>
-        <button class="cell" ng-click="vm.doArchiveForms()"><i18n>formulaire.archive</i18n></button>
+        <button class="cell" ng-click="vm.doArchiveForms()" ng-disabled="vm.isProcessing"><i18n>formulaire.archive</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/template/lightbox/form-export.html
+++ b/formulaire/src/main/resources/public/template/lightbox/form-export.html
@@ -34,6 +34,6 @@
     <!-- Buttons -->
     <div ng-if="!vm.display.loading.export" class="action-buttons">
         <button class="cell cancel" ng-click="vm.closeExportForms()"><i18n>formulaire.close</i18n></button>
-        <button class="cell" ng-click="vm.doExportForms()" ng-disabled="vm.isProcessing"><i18n>formulaire.export</i18n></button>
+        <button class="cell" ng-click="vm.doExportForms()" ng-disabled="vm.display.loading.export"><i18n>formulaire.export</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/template/lightbox/form-export.html
+++ b/formulaire/src/main/resources/public/template/lightbox/form-export.html
@@ -34,6 +34,6 @@
     <!-- Buttons -->
     <div ng-if="!vm.display.loading.export" class="action-buttons">
         <button class="cell cancel" ng-click="vm.closeExportForms()"><i18n>formulaire.close</i18n></button>
-        <button class="cell" ng-click="vm.doExportForms()"><i18n>formulaire.export</i18n></button>
+        <button class="cell" ng-click="vm.doExportForms()" ng-disabled="vm.isProcessing"><i18n>formulaire.export</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/template/lightbox/questions-reorganization.html
+++ b/formulaire/src/main/resources/public/template/lightbox/questions-reorganization.html
@@ -31,6 +31,6 @@
     </div>
     <div class="action-buttons">
         <button class="cell cancel" ng-click="vm.cancelOrganizeFormElements()"><i18n>formulaire.cancel</i18n></button>
-        <button class="cell" id="organizeConfirm" ng-click="vm.doOrganizeFormElements()"><i18n>formulaire.confirm</i18n></button>
+        <button class="cell" id="organizeConfirm" ng-click="vm.doOrganizeFormElements()" ng-disabled="vm.isProcessing"><i18n>formulaire.confirm</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/template/lightbox/responses-confirm-sending.html
+++ b/formulaire/src/main/resources/public/template/lightbox/responses-confirm-sending.html
@@ -26,6 +26,6 @@
     </div>
     <div class="action-buttons">
         <button class="cell cancel" ng-click="vm.display.lightbox.sending = false;"><i18n>formulaire.cancel</i18n></button>
-        <button class="cell" ng-click="vm.doSend()"><i18n>formulaire.confirm</i18n></button>
+        <button class="cell" ng-click="vm.doSend()" ng-disabled="vm.isProcessing"><i18n>formulaire.confirm</i18n></button>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -65,6 +65,7 @@ interface ViewModel {
     nestedSortables: any[];
     iconUtils: IconUtils;
     initializing: boolean;
+    isProcessing: boolean;
 
     $onInit() : Promise<void>;
 
@@ -137,6 +138,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         // Global functions
 
         vm.saveAll = async (displaySuccess= true) : Promise<void> => {
+            vm.isProcessing = true;
             vm.dontSave = true;
 
             // Check conditional questions
@@ -185,6 +187,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
 
             await saveFormElements(displaySuccess && wrongElements.length <= 0);
             vm.dontSave = false;
+            vm.isProcessing = false;
         };
 
 
@@ -261,6 +264,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         };
 
         vm.doOrganizeFormElements = async () : Promise<void> => {
+            vm.isProcessing = true;
             for (let question of vm.formElements.getAllQuestions().all) {
                 if ((question.section_id || question.section_position) && question.position) {
                     if (question.position > 0) {
@@ -275,6 +279,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
 
             await formElementService.update(vm.formElements.getAllSectionsAndAllQuestions());
             vm.display.lightbox.reorganization = false;
+            vm.isProcessing = false;
             template.close('lightbox');
             $scope.safeApply();
         };
@@ -821,6 +826,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
 
         const onClickQuestion = async (event) : Promise<void> => {
             if (!vm.dontSave && $scope.currentPage === Pages.EDIT_FORM) {
+                vm.isProcessing = true;
                 let question = isInFocusable(event.target);
                 if (question && question.id && question.id > 0) {
                     if (!question.selected) {
@@ -839,6 +845,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                 else if(!isInDontSave(event.target)) {
                     await saveFormElements();
                 }
+                vm.isProcessing = false;
                 $scope.safeApply();
             }
         };

--- a/formulaire/src/main/resources/public/ts/controllers/form-prop.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-prop.ts
@@ -12,7 +12,8 @@ interface ViewModel {
     rgpdLifetimeChoices: number[];
     display: {
         date_ending: boolean
-    }
+    },
+    isProcessing: boolean;
 
     $onInit() : Promise<void>;
     saveGuard(): void;
@@ -33,6 +34,7 @@ export const formPropController = ng.controller('FormPropController', ['$scope',
         vm.display = {
             date_ending: false
         };
+        vm.isProcessing = false;
 
         vm.$onInit = async () : Promise<void> => {
             vm.form = $scope.form;
@@ -52,8 +54,10 @@ export const formPropController = ng.controller('FormPropController', ['$scope',
         };
 
         vm.save = async () : Promise<void> => {
-            if (vm.form.title && vm.checkIntervalDates()) {
+            if (vm.form.title && vm.checkIntervalDates() && !vm.isProcessing) {
+                vm.isProcessing = true;
                 vm.form = await formService.save(vm.form);
+                vm.isProcessing = false;
                 $scope.redirectTo(`/form/${vm.form.id}/edit`);
                 $scope.safeApply();
             }

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -76,6 +76,7 @@ interface ViewModel {
     draggable : Draggable;
     draggedItem : any;
     exportFormat: Exports;
+    isProcessing: boolean;
 
     importForms() : void;
     doImportForms(): Promise<void>;
@@ -195,6 +196,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
     vm.folderTree = {};
     vm.openedFoldersIds = null;
     vm.selectedFolder = null;
+    vm.isProcessing = false;
 
     vm.$onInit = async () : Promise<void> => {
         await initFormsList();

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -268,6 +268,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
     };
 
     vm.duplicateForms = async () : Promise<void> => {
+        vm.isProcessing = true;
         try {
             let formIds = [];
             for (let form of vm.forms.selected) {
@@ -279,6 +280,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
             await formService.duplicate(formIds, targetFolderId);
             notify.success(idiom.translate('formulaire.success.forms.duplicate'));
             vm.openFolder(vm.folder);
+            vm.isProcessing = false;
             $scope.safeApply();
         }
         catch (e) {
@@ -407,6 +409,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
 
     vm.doExportForms = async () : Promise<void> => {
         vm.display.loading.export = true;
+        vm.isProcessing = true;
 
         // Generate document PDF and store it in a blob
         try {
@@ -425,6 +428,7 @@ export const formsListController = ng.controller('FormsListController', ['$scope
                     vm.closeExportForms();
                 },5000);
             }
+            vm.isProcessing = false;
         }
         catch (err) {
             vm.display.loading.export = false;
@@ -507,12 +511,14 @@ export const formsListController = ng.controller('FormsListController', ['$scope
 
     vm.doArchiveForms = async () : Promise<void> => {
         try {
+            vm.isProcessing = true;
             for (let form of vm.forms.selected) {
                 await formService.archive(form, vm.folders.archivedFormsFolder.id);
             }
             template.close('lightbox');
             vm.display.lightbox.archive = false;
             vm.display.warning = false;
+            vm.isProcessing = false;
             notify.success(idiom.translate('formulaire.success.forms.archive'));
             vm.openFolder(vm.folder);
             $scope.safeApply();

--- a/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/forms-list.ts
@@ -409,7 +409,6 @@ export const formsListController = ng.controller('FormsListController', ['$scope
 
     vm.doExportForms = async () : Promise<void> => {
         vm.display.loading.export = true;
-        vm.isProcessing = true;
 
         // Generate document PDF and store it in a blob
         try {
@@ -428,7 +427,6 @@ export const formsListController = ng.controller('FormsListController', ['$scope
                     vm.closeExportForms();
                 },5000);
             }
-            vm.isProcessing = false;
         }
         catch (err) {
             vm.display.loading.export = false;

--- a/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
@@ -25,6 +25,7 @@ interface ViewModel {
             sending: boolean
         }
     };
+    isProcessing: boolean;
 
     $onInit(): Promise<void>;
     send(): Promise<void>;
@@ -95,6 +96,7 @@ export const recapQuestionsController = ng.controller('RecapQuestionsController'
         let distrib = vm.distribution;
         distrib.status = DistributionStatus.FINISHED;
         distrib.structure = distrib.structure ? distrib.structure : model.me.structureNames[0];
+        vm.isProcessing = true;
 
         if (distrib.original_id) {
             let questionFileIds: any = vm.formElements.all.filter(q => q instanceof Question && q.question_type === Types.FILE).map(q => q.id);
@@ -111,6 +113,7 @@ export const recapQuestionsController = ng.controller('RecapQuestionsController'
         }
         template.close('lightbox');
         vm.display.lightbox.sending = false;
+        vm.isProcessing = false;
         notify.success(idiom.translate('formulaire.success.responses.save'));
         window.setTimeout(function () { $scope.redirectTo(`/list/responses`); }, 1000);
     };

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -31,6 +31,7 @@ interface ViewModel {
     currentResponses: Map<Question, Responses>;
     currentFiles: Map<Question, File[]>;
     currentQuestionFiles: File[];
+    isProcessing: boolean;
 
     $onInit() : Promise<void>;
     prev() : Promise<void>;
@@ -165,12 +166,14 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 
     vm.next = async () : Promise<void> => {
         let nextPosition: number = getNextPositionIfValid();
+        vm.isProcessing = true;
         if (nextPosition && nextPosition <= vm.nbFormElements) {
             await saveResponses();
             vm.formElement = vm.formElements.all[nextPosition - 1];
             vm.longestPath = findLongestPathInFormElement(vm.formElement.id, vm.formElements);
             vm.historicPosition.push(vm.formElement.position);
             vm.longestPath = vm.historicPosition.length + findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+            vm.isProcessing = false;
             goToFormElement();
         }
         else if (nextPosition !== undefined) {
@@ -179,6 +182,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
                 path: `/form/${vm.form.id}/${vm.distribution.id}/questions/recap`,
                 historicPosition: vm.historicPosition
             };
+            vm.isProcessing = false;
             $scope.$emit(FORMULAIRE_EMIT_EVENT.REDIRECT, data);
         }
     };

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -151,13 +151,15 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 
     vm.prev = async () : Promise<void> => {
         let prevPosition: number = vm.historicPosition[vm.historicPosition.length - 2];
+        vm.isProcessing = true;
         if (prevPosition > 0) {
             await saveResponses();
             vm.formElement = vm.formElements.all[prevPosition - 1];
             vm.historicPosition.pop();
             vm.longestPath = vm.historicPosition.length + findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
             goToFormElement();
-        }
+        };
+        vm.isProcessing = false;
     };
 
     vm.prevGuard = () => {


### PR DESCRIPTION
## Describe your changes
Added ng-disable to prevent certain buttons spamming and consequences

## Checklist tests
Here is the list of impacted's buttons : 
edit-form : saveAll
prop-form : saveGuard
toaster-forms-list : duplicateForm 
forms-list : doExportForms 
forms-list : doArchiveForms 
respond-question : next 
recap-question : doSend  
captcha : doSend 

## Issue ticket number and link
[FOR-595](https://jira.support-ent.fr/browse/FOR-595)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)