### PR TITLE
fix(update): #FOR-715 delete empty matrix questionChoice when updating

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -775,7 +775,7 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                         for (let choice of formElement.choices.all) {
                             if (!choice.value && choice.id) {
                                 await questionChoiceService.delete(choice.id);
-                            } else if (choice.value && !registeredChoiceValues.find((v: string) => v === choice.value)) {
+                            } else if (choice.value && !registeredChoiceValues.some((v: string) => v === choice.value)) {
                                 choice.position = positionCounter;
                                 choice.question_id = newId;
                                 choice.id = (await questionChoiceService.save(choice)).id;

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -773,7 +773,9 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
                         formElement.choices.replaceSpace();
                         let positionCounter: number = 1;
                         for (let choice of formElement.choices.all) {
-                            if (choice.value && !registeredChoiceValues.find((v: string) => v === choice.value)) {
+                            if (!choice.value && choice.id) {
+                                await questionChoiceService.delete(choice.id);
+                            } else if (choice.value && !registeredChoiceValues.find((v: string) => v === choice.value)) {
                                 choice.position = positionCounter;
                                 choice.question_id = newId;
                                 choice.id = (await questionChoiceService.save(choice)).id;


### PR DESCRIPTION
## Describe your changes
In a matrix form element, when you want to delete a question choice (matrix column), you can click on the cross corresponding to the input.
Now if you remove the string value of the input, the question choice will also be delated when updating.
This change fits the behaviour of matrix children (lines).
## Checklist tests
Edit an existing form with matrix columns.
Remove existing value of a column and click outside of the matrix form element.
## Issue ticket number and link
[FOR-715](https://jira.support-ent.fr/browse/FOR-715)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)