### PR TITLE
fix(doSend): #FOR-713 remove deleteAll files instruction when sending  response

### DIFF
--- a/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/recap-questions.ts
@@ -99,11 +99,6 @@ export const recapQuestionsController = ng.controller('RecapQuestionsController'
         vm.isProcessing = true;
 
         if (distrib.original_id) {
-            let questionFileIds: any = vm.formElements.all.filter(q => q instanceof Question && q.question_type === Types.FILE).map(q => q.id);
-            let responseFiles = vm.responses.all.filter(r => questionFileIds.includes(r.question_id));
-            for (let responseFile of responseFiles) {
-                await responseFileService.deleteAll(responseFile.original_id);
-            }
             await cleanResponses();
             await distributionService.replace(distrib);
         }


### PR DESCRIPTION
## Describe your changes
This ticket deals with a responder wanting to change the files in a question of type file.
When modifying his response, he had an error concerning the deletion of the former file(s).
In order to clean storage, there was an instruction to remove all the files of a specific response when updating it (if we change the files). But actually, this instruction is already called when updating files in the saveFiles function :
**await responseFileService.deleteAll(response.id);**
As the former file was already removed from the storage, it could not find the file afterward and so could not remove it again.
We simply removed this instruction in the code.

## Checklist tests
Create a form with a question of type file. Then share it to someone. Then answer to the form (when logged as the responder) by uploading a file, save and send.
Re open your form and modify the file and send it again.
## Issue ticket number and link
[FOR-713](https://jira.support-ent.fr/browse/FOR-713)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)