### PR TITLE
fix(recap): [#FOR-302] hide "Modify" buttons when form is not editable

### DIFF
--- a/formulaire/src/main/resources/public/ts/directives/question/recap-question-item/recap-question-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/question/recap-question-item/recap-question-item.html
@@ -114,7 +114,7 @@
             </div>
         </div>
     </div>
-    <div class="question-edit" ng-if="(vm.form.editable || vm.distribution.status != vm.DistributionStatus.FINISHED)
+    <div class="question-edit" ng-if="(vm.form.editable || vm.distribution.status != vm.distributionStatus.FINISHED)
                     && vm.question.question_type != vm.types.FREETEXT">
         <a ng-click="vm.openQuestion()"><i18n>formulaire.edit</i18n></a>
     </div>


### PR DESCRIPTION
## Describe your changes
When refactoring the racp-item directive we whange the name of a variable but forgot an occurence in HTML code, creating a bug.
Now the HTML calls the right variable name.

## Checklist tests

## Issue ticket number and link
FOR-302 : https://jira.support-ent.fr/browse/FOR-302

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)