### PR TITLE
fix(zip): #FOR-698 handle display of images in imported form

### DIFF
--- a/common/src/main/java/fr/openent/form/core/constants/Fields.java
+++ b/common/src/main/java/fr/openent/form/core/constants/Fields.java
@@ -220,6 +220,7 @@ public class Fields {
     public static final String IS_SHORT_ANSWER = "is_short_answer";
     public static final String SIZE = "size";
     public static final String SLASH = "/";
+    public static final String IMAGE_PATH_PREFIX = "/workspace/document/";
     public static final String SPECIFIC_FIELDS = "specific_fields";
     public static final String STATEMENTS = "statements";
     public static final String SUBJECT = "subject";

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/FormulaireRepositoryEvents.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/FormulaireRepositoryEvents.java
@@ -210,7 +210,7 @@ public class FormulaireRepositoryEvents extends SqlRepositoryEvents {
             .compose(documentsIdMapping -> {
                 JsonObject questionChoices = tableContents.get(QUESTION_CHOICE);
                 updateImageIds(questionChoices.getJsonArray(FIELDS).getList(), questionChoices.getJsonArray(RESULTS), documentsIdMapping);
-                return importExportService.importQuestionChoices(tableContents.get(QUESTION_CHOICE), tableMappingIds.get(QUESTION), tableMappingIds.get(SECTION));
+                return importExportService.importQuestionChoices(questionChoices, tableMappingIds.get(QUESTION), tableMappingIds.get(SECTION));
             })
             .compose(newQuestionChoices -> importExportService.createFolderLinks(tableMappingIds.get(FORM), userId))
             .onSuccess(result -> {
@@ -240,10 +240,11 @@ public class FormulaireRepositoryEvents extends SqlRepositoryEvents {
     protected void updateImageIds(List<String> fields, JsonArray results, Map<String, String> documentsIdMapping ) {
         for (int i = 0; i < results.size(); ++i) {
             JsonArray entry = results.getJsonArray(i);
-            String imageValue = entry.getString(fields.indexOf(IMAGE));
-            String regexValue = imageValue != null && !imageValue.isEmpty() ? imageValue.replace(IMAGE_PATH_PREFIX, "") : null;
-            if (regexValue != null && documentsIdMapping.containsKey(regexValue)) {
-                entry.set(fields.indexOf(IMAGE), IMAGE_PATH_PREFIX + documentsIdMapping.get(regexValue));
+            int columnImageIndex = fields.indexOf(IMAGE);
+            String imageValue = entry.getString(columnImageIndex);
+            String imageId = imageValue != null && !imageValue.isEmpty() ? imageValue.replace(IMAGE_PATH_PREFIX, "") : null;
+            if (imageId != null && documentsIdMapping.containsKey(imageId)) {
+                entry.set(columnImageIndex, IMAGE_PATH_PREFIX + documentsIdMapping.get(imageId));
             }
         }
     }

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/FormulaireRepositoryEvents.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/FormulaireRepositoryEvents.java
@@ -1,8 +1,10 @@
 package fr.openent.formulaire.service.impl;
 
 import fr.openent.form.helpers.FutureHelper;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.entcore.common.folders.FolderImporter;
 import org.entcore.common.service.impl.SqlRepositoryEvents;
 import org.entcore.common.sql.Sql;
 import org.entcore.common.sql.SqlResult;
@@ -13,6 +15,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import java.io.File;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -178,8 +181,8 @@ public class FormulaireRepositoryEvents extends SqlRepositoryEvents {
             .compose(forms -> importExportService.getTableContent(importPath, schema, SECTION, tableContents))
             .compose(sections -> importExportService.getTableContent(importPath, schema, QUESTION, tableContents))
             .compose(questions -> importExportService.getTableContent(importPath, schema, QUESTION_CHOICE, tableContents))
-            .compose(questionSpecifics -> importExportService.getTableContent(importPath, schema, QUESTION_SPECIFIC_FIELDS, tableContents))
-            .compose(questionChoices -> importExportService.importForms(tableContents.get(FORM), userId, userName))
+            .compose(questionChoices -> importExportService.getTableContent(importPath, schema, QUESTION_SPECIFIC_FIELDS, tableContents))
+            .compose(questionSpecifics -> importExportService.importForms(tableContents.get(FORM), userId, userName))
             .compose(oldNewFormIds -> {
                 Map<Integer, Integer> oldNewFormIdsMap = importExportService.generateMappingIntInt(oldNewFormIds, ORIGINAL_FORM_ID, ID);
                 tableMappingIds.put(FORM, oldNewFormIdsMap);
@@ -203,13 +206,13 @@ public class FormulaireRepositoryEvents extends SqlRepositoryEvents {
                 tableMappingIds.get(QUESTION).putAll(oldNewChildrenQuestionIdsMap);
                 return importExportService.importQuestionSpecifics(tableContents.get(QUESTION_SPECIFIC_FIELDS), tableMappingIds.get(QUESTION));
             })
-            .compose(newQuestionSpecifics -> importExportService.importQuestionChoices(tableContents.get(QUESTION_CHOICE), tableMappingIds.get(QUESTION), tableMappingIds.get(SECTION)))
-            .compose(newQuestionChoices -> {
-                Promise<JsonArray> promise = Promise.promise();
-                super.importDocumentsDependancies(importPath, userId, userName, new SqlStatementsBuilder().build(), FutureHelper.handler(promise));
-                return promise.future();
+            .compose(newQuestionSpecifics -> customImportDocumentsDependencies(importPath, userId, userName, builder.build()))
+            .compose(documentsIdMapping -> {
+                JsonObject questionChoices = tableContents.get(QUESTION_CHOICE);
+                updateImageIds(questionChoices.getJsonArray(FIELDS).getList(), questionChoices.getJsonArray(RESULTS), documentsIdMapping);
+                return importExportService.importQuestionChoices(tableContents.get(QUESTION_CHOICE), tableMappingIds.get(QUESTION), tableMappingIds.get(SECTION));
             })
-            .compose(attachments -> importExportService.createFolderLinks(tableMappingIds.get(FORM), userId))
+            .compose(newQuestionChoices -> importExportService.createFolderLinks(tableMappingIds.get(FORM), userId))
             .onSuccess(result -> {
                 int nbFormsImported = tableMappingIds.get(FORM).size();
                 JsonObject finalResultInfos = new JsonObject().put(STATUS, OK)
@@ -232,6 +235,35 @@ public class FormulaireRepositoryEvents extends SqlRepositoryEvents {
                 err.printStackTrace();
                 handler.handle(finalResultInfos);
             });
+    }
+
+    protected void updateImageIds(List<String> fields, JsonArray results, Map<String, String> documentsIdMapping ) {
+        for (int i = 0; i < results.size(); ++i) {
+            JsonArray entry = results.getJsonArray(i);
+            String imageValue = entry.getString(fields.indexOf(IMAGE));
+            String regexValue = imageValue != null && !imageValue.isEmpty() ? imageValue.replace(IMAGE_PATH_PREFIX, "") : null;
+            if (regexValue != null && documentsIdMapping.containsKey(regexValue)) {
+                entry.set(fields.indexOf(IMAGE), IMAGE_PATH_PREFIX + documentsIdMapping.get(regexValue));
+            }
+        }
+    }
+
+    protected Future<Map<String, String>> customImportDocumentsDependencies(String importPath, String userId, String userName, JsonArray statements) {
+        Promise<Map<String, String>> promise = Promise.promise();
+        final String filePath = importPath + File.separator + DOCUMENTS;
+        fs.exists(filePath, exist -> {
+            if (exist.failed() || !exist.result()) {
+                promise.complete(new HashMap<>());
+                return;
+            }
+
+            FolderImporter.FolderImporterContext ctx = new FolderImporter.FolderImporterContext(filePath, userId, userName);
+            fileImporter.importFoldersFlatFormat(ctx, rapport -> { // import in mongo + generate mapOldNewIds
+                promise.complete(ctx.oldIdsToNewIds);
+            });
+        });
+
+        return promise.future();
     }
 
 


### PR DESCRIPTION
## Describe your changes
We now update the ids of images when importing a form to avoid any display issue.
Indeed, before that, every image imported kept the former id of image exported in the original form which was confusing and led to non valid image paths.
## Checklist tests
Import a form with QCM images several times to make sure images are well displayed.
## Issue ticket number and link
[FOR-698](https://jira.support-ent.fr/browse/FOR-698)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)