### PR TITLE
fix(restore): #FOR-753 cast dateEnding to string when uptade

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
@@ -511,7 +511,7 @@ public class DefaultFormService implements FormService {
                         .add(form.getPicture() != null ? form.getPicture() : "")
                         .add("NOW()")
                         .add(form.getDateOpening() != null ? form.getDateOpening().toString() : "NOW()")
-                        .add(form.getDateEnding())
+                        .add(form.getDateEnding() != null ? form.getDateEnding().toString() : null)
                         .add(form.getSent())
                         .add(form.getCollab())
                         .add(form.getReminded())


### PR DESCRIPTION
## Describe your changes
When a form is restored, we have to update it in dataBase and the ending date of the form was typed as a date instead of a string so we add an internal error.
## Checklist tests
Create a public form, delete it restore it through the files trash.
## Issue ticket number and link
[FOR-753](https://jira.support-ent.fr/browse/FOR-753)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)