### PR TITLE
fix(conditional): [#FOR-782] fix choice targeting on elements reorganization

### DIFF
--- a/common/src/main/resources/ts/services/QuestionChoiceService.ts
+++ b/common/src/main/resources/ts/services/QuestionChoiceService.ts
@@ -1,6 +1,10 @@
 import {idiom, ng, notify} from 'entcore';
 import http from 'axios';
-import {QuestionChoice, QuestionChoicePayload} from '../models';
+import {
+    IQuestionChoiceResponse,
+    QuestionChoice,
+    QuestionChoicePayload
+} from '../models';
 import {DataUtils} from "../utils";
 
 export interface QuestionChoiceService {
@@ -9,6 +13,7 @@ export interface QuestionChoiceService {
     save(choice: QuestionChoice) : Promise<any>;
     create(choice: QuestionChoice) : Promise<any>;
     update(choice: QuestionChoice) : Promise<any>;
+    updateMultiple(choices: QuestionChoice[], formId: number) : Promise<QuestionChoice[]>;
     delete(choiceId: number) : Promise<any>;
 }
 
@@ -55,6 +60,16 @@ export const questionChoiceService: QuestionChoiceService = {
             return DataUtils.getData(await http.put(`/formulaire/choices/${choice.id}`, choicePayload, { headers: { Accept: 'application/json;version=1.9'} }));
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.questionChoiceService.update'));
+            throw err;
+        }
+    },
+
+    async updateMultiple(choices: QuestionChoice[], formId: number) : Promise<QuestionChoice[]> {
+        try {
+            let choicesPayload: QuestionChoicePayload[] = choices.map((c: QuestionChoice) => new QuestionChoicePayload(c));
+            let data: IQuestionChoiceResponse[] = DataUtils.getData(await http.put(`/formulaire/${formId}/choices`, choicesPayload));
+            return data.map((qcr: IQuestionChoiceResponse) => new QuestionChoice().build(qcr));
+        } catch (err) {
             throw err;
         }
     },

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormElementController.java
@@ -115,7 +115,7 @@ public class FormElementController extends ControllerHelper {
                             .map(Question.class::cast)
                             .flatMap(q -> q.getChoices().stream())
                             .collect(Collectors.toList());
-                    return questionChoiceService.update(choices, I18n.acceptLanguage(request));
+                    return questionChoiceService.updateOld(choices, I18n.acceptLanguage(request));
                 })
                 .onSuccess(result -> renderJson(request, result))
                 .onFailure(err -> {

--- a/formulaire/src/main/java/fr/openent/formulaire/security/CustomShareAndOwner.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/security/CustomShareAndOwner.java
@@ -87,8 +87,9 @@ public class CustomShareAndOwner implements ResourcesProvider {
                 isGetForm(binding) || isUpdateForm(binding) || isDeleteForm(binding) || isSendReminderForm(binding) ||
                 isGetMyFormRightsForm(binding) || isCountFormElements(binding) || isGetByPositionFormElement(binding) ||
                 isUpdateFormElement(binding) || isListForFormQuestion(binding) || isListForFormAndSectionQuestion(binding) ||
-                isCreateQuestion(binding) || isListByFormResponse(binding) || isDeleteResponse(binding) || isExportResponse(binding) ||
-                isListSection(binding) || isCreateSection(binding) || isUpdateSection(binding) || isUpdateQuestion(binding)) {
+                isCreateQuestion(binding) || isUpdateMultipleQuestionChoice(binding) || isListByFormResponse(binding) ||
+                isDeleteResponse(binding) || isExportResponse(binding) || isListSection(binding) || isCreateSection(binding) ||
+                isUpdateSection(binding) || isUpdateQuestion(binding)) {
             return PARAM_FORM_ID;
         }
         else if (isGetDistribution(binding) || isAddDistribution(binding) || isUpdateDistribution(binding) ||
@@ -204,6 +205,10 @@ public class CustomShareAndOwner implements ResourcesProvider {
 
     private boolean isUpdateQuestionChoice(final Binding binding) {
         return bindingIsThatMethod(binding, HttpMethod.PUT, "fr.openent.formulaire.controllers.QuestionChoiceController|update");
+    }
+
+    private boolean isUpdateMultipleQuestionChoice(final Binding binding) {
+        return bindingIsThatMethod(binding, HttpMethod.PUT, "fr.openent.formulaire.controllers.QuestionChoiceController|updateMultiple");
     }
 
     private boolean isDeleteQuestionChoice(final Binding binding) {

--- a/formulaire/src/main/java/fr/openent/formulaire/service/QuestionChoiceService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/QuestionChoiceService.java
@@ -66,7 +66,14 @@ public interface QuestionChoiceService {
      * @param choices List<QuestionChoice> data
      * @param locale locale language
      */
-    Future<JsonArray> update(List<QuestionChoice> choices, String locale);
+    Future<JsonArray> updateOld(List<QuestionChoice> choices, String locale);
+
+    /**
+     * Update a list of specific choices
+     * @param choices List<QuestionChoice> data
+     * @param locale locale language
+     */
+    Future<List<QuestionChoice>> update(List<QuestionChoice> choices, String locale);
 
     /**
      * Delete a specific choice

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -30,11 +30,12 @@ import {
     Pages
 } from "@common/core/enums";
 import * as Sortable from "sortablejs";
-import {FormElementUtils} from "@common/utils";
+import {DataUtils, FormElementUtils} from "@common/utils";
 import {Constants} from "@common/core/constants";
 import {PropPosition} from "@common/core/enums/prop-position";
 import {FormElementType} from "@common/core/enums/form-element-type";
 import {IconUtils} from "@common/utils/icon";
+import http from "axios";
 
 enum PreviewPage { RGPD = 'rgpd', QUESTION = 'question', RECAP = 'recap'}
 
@@ -280,6 +281,12 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             }
 
             await formElementService.update(vm.formElements.getAllSectionsAndAllQuestions());
+            try {
+                await questionChoiceService.updateMultiple(FormElementUtils.getConditionalQuestionsChoices(vm.formElements), vm.form.id);
+            } catch (err) {
+                notify.error(idiom.translate('formulaire.error.questionChoiceService.update'));
+                throw err;
+            }
             vm.display.lightbox.reorganization = false;
             vm.isProcessing = false;
             template.close('lightbox');

--- a/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-singleanswer/question-type-singleanswer.directive.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/question-type/question-type-singleanswer/question-type-singleanswer.directive.ts
@@ -48,10 +48,23 @@ class Controller implements IViewModel {
     }
 
     $onInit = async () : Promise<void> => {
-        for (let choice of this.question.choices.all) {
-            choice.next_form_element = choice.getNextFormElement(this.formElements, this.question);
-        }
         this.followingFormElement = this.question.getFollowingFormElement(this.formElements);
+        let questionPosition: number = this.question.getPosition(this.formElements);
+        for (let choice of this.question.choices.all) {
+            let nextFormElement: FormElement = choice.getNextFormElement(this.formElements, this.question);
+            if (nextFormElement && nextFormElement.position > questionPosition) {
+                choice.next_form_element = nextFormElement;
+            }
+            else if (nextFormElement) {
+                choice.next_form_element = this.followingFormElement;
+                choice.next_form_element_id = this.followingFormElement.id;
+                choice.next_form_element_type = this.followingFormElement.form_element_type;
+                choice.is_next_form_element_default = true;
+            }
+            else {
+                choice.next_form_element = undefined;
+            }
+        }
     }
 
     $onDestroy = async () : Promise<void> => {}

--- a/formulaire/src/main/resources/sql/028-add-sharing-rights.sql
+++ b/formulaire/src/main/resources/sql/028-add-sharing-rights.sql
@@ -1,0 +1,5 @@
+INSERT INTO formulaire.form_shares (
+    SELECT member_id, resource_id, 'fr-openent-formulaire-controllers-QuestionChoiceController|updateMultiple'
+    FROM formulaire.form_shares
+    WHERE action = 'fr-openent-formulaire-controllers-FormController|initContribResourceRight'
+) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Describe your changes
We now save all choices from conditional questions after DnD.
It allows to save potential target changes generated by positions changing.

Documentation API : https://confluence.support-ent.fr/display/FOR/Question+Choice#operations-tag-default

## Checklist tests

## Issue ticket number and link
FOR-782 : https://jira.support-ent.fr/browse/FOR-782

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)