### PR TITLE
fix(reorganization): [#FOR-804] fix front services when params are empty

### DIFF
--- a/common/src/main/resources/ts/services/FormElement/QuestionService.ts
+++ b/common/src/main/resources/ts/services/FormElement/QuestionService.ts
@@ -42,6 +42,7 @@ export const questionService: QuestionService = {
 
     async listChildren(questions: Question[]) : Promise<Question[]> {
         try {
+            if (!questions || questions.length <= 0) return [];
             let questionIds: number[] = questions.map((q: Question) => q.id);
             let data: IQuestionResponse[] = DataUtils.getData(await http.get(`/formulaire/questions/children`, { params: questionIds, headers: { Accept: 'application/json;version=2.0'} }));
             return data.map((qr: IQuestionResponse) => new Question().build(qr));
@@ -75,9 +76,7 @@ export const questionService: QuestionService = {
 
     async create(questions: Question[]) : Promise<Question[]> {
         try {
-            if (questions.length <= 0) {
-                return [];
-            }
+            if (!questions || questions.length <= 0) return [];
             let questionsPayload: QuestionPayload[] = questions.map((q: Question) => new QuestionPayload(q));
             return DataUtils.getData(await http.post(`/formulaire/forms/${questionsPayload[0].form_id}/questions`, questionsPayload));
         } catch (err) {
@@ -89,9 +88,7 @@ export const questionService: QuestionService = {
 
     async update(questions: Question[]) : Promise<Question[]> {
         try {
-            if (questions.length <= 0) {
-                return [];
-            }
+            if (!questions || questions.length <= 0) return [];
             let questionsPayload: QuestionPayload[] = questions.map((q: Question) => new QuestionPayload(q));
             let data: IQuestionResponse[] = DataUtils.getData(await http.put(`/formulaire/forms/${questions[0].form_id}/questions`, questionsPayload))
             return data.map((qr: IQuestionResponse) => new Question().build(qr));

--- a/common/src/main/resources/ts/services/FormElement/SectionService.ts
+++ b/common/src/main/resources/ts/services/FormElement/SectionService.ts
@@ -51,9 +51,7 @@ export const sectionService: SectionService = {
 
     async update(sections: Section[]) : Promise<Section[]> {
         try {
-            if (sections.length <= 0) {
-                return [];
-            }
+            if (!sections || sections.length <= 0) return [];
             let sectionsPayload: SectionPayload[] = sections.map((s: Section) => new SectionPayload(s));
             let data: any = DataUtils.getData(await http.put(`/formulaire/forms/${sections[0].form_id}/sections`, sectionsPayload));
             let updatedSections: Section[] = Mix.castArrayAs(Section, data);

--- a/common/src/main/resources/ts/services/FormService.ts
+++ b/common/src/main/resources/ts/services/FormService.ts
@@ -20,7 +20,7 @@ export interface FormService {
     move(formIds : number[], parentId: number) : Promise<any>;
     sendReminder(formId: number, mail: {}) : Promise<any>;
     exportPdf(formIds: number[]) : Promise<any>;
-    exportZip(formIds: number[]) : Promise<any>;
+    exportZip(formIds: number[]) : Promise<string>;
     verifyExportAndDownloadZip(exportId: string) : Promise<void>;
     import(zipFile: FormData) : Promise<any>;
     unshare(formId: number) : Promise<any>;
@@ -91,6 +91,7 @@ export const formService: FormService = {
 
     async duplicate(formIds: number[], folderId: number) : Promise<any> {
         try {
+            if (!formIds || formIds.length <= 0) return [];
             return DataUtils.getData(await http.post(`/formulaire/forms/duplicate/${folderId}`, formIds));
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.formService.duplicate'));
@@ -120,6 +121,7 @@ export const formService: FormService = {
 
     async restore(forms: Form[]) : Promise<any> {
         try {
+            if (!forms || forms.length <= 0) return [];
             return DataUtils.getData(await http.put(`/formulaire/forms/restore`, forms.map(f => f.id)));
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.formService.restore'));
@@ -137,8 +139,9 @@ export const formService: FormService = {
         }
     },
 
-    async move(formIds, parentId) : Promise<any> {
+    async move(formIds: number[], parentId: number) : Promise<any> {
         try {
+            if (!formIds || formIds.length <= 0) return [];
             return DataUtils.getData(await http.put(`/formulaire/forms/move/${parentId}`, formIds));
         } catch (e) {
             notify.error(idiom.translate('formulaire.error.formService.move'));
@@ -157,6 +160,7 @@ export const formService: FormService = {
 
     async exportPdf(formIds: number[]) : Promise<any> {
         try {
+            if (!formIds || formIds.length <= 0) return [];
             return await http.get(`/formulaire/forms/export/pdf`, { params: formIds });
         } catch (err) {
             notify.error(idiom.translate('formulaire.error.formService.export'));
@@ -164,8 +168,9 @@ export const formService: FormService = {
         }
     },
 
-    async exportZip(formIds: number[]) : Promise<any> {
+    async exportZip(formIds: number[]) : Promise<string> {
         try {
+            if (!formIds || formIds.length <= 0) return null;
             let res = await http.post(`/formulaire/forms/export/zip`, formIds);
             return res.data.exportId;
         } catch (err) {

--- a/common/src/main/resources/ts/services/QuestionChoiceService.ts
+++ b/common/src/main/resources/ts/services/QuestionChoiceService.ts
@@ -30,9 +30,7 @@ export const questionChoiceService: QuestionChoiceService = {
 
     async listChoices(questionIds: number[]) : Promise<any>{
         try{
-            if (questionIds.length <= 0) {
-                return [];
-            }
+            if (!questionIds || questionIds.length <= 0) return [];
             return DataUtils.getData(await http.get(`/formulaire/questions/choices/all`, { params: questionIds, headers: { Accept: 'application/json;version=1.9'} }));
         } catch(err){
             notify.error(idiom.translate('formulaire.error.questionChoiceService.list'));
@@ -66,6 +64,7 @@ export const questionChoiceService: QuestionChoiceService = {
 
     async updateMultiple(choices: QuestionChoice[], formId: number) : Promise<QuestionChoice[]> {
         try {
+            if (!choices || choices.length <= 0) return [];
             let choicesPayload: QuestionChoicePayload[] = choices.map((c: QuestionChoice) => new QuestionChoicePayload(c));
             let data: IQuestionChoiceResponse[] = DataUtils.getData(await http.put(`/formulaire/${formId}/choices`, choicesPayload));
             return data.map((qcr: IQuestionChoiceResponse) => new QuestionChoice().build(qcr));

--- a/common/src/main/resources/ts/services/ResponseService.ts
+++ b/common/src/main/resources/ts/services/ResponseService.ts
@@ -59,6 +59,7 @@ export const responseService: ResponseService = {
 
     async listMineByDistributionAndQuestions(questionIds: number[], distributionId: number) : Promise<Response[]> {
         try {
+            if (!questionIds || questionIds.length <= 0) return [];
             let data: IResponseResponse[] = DataUtils.getData(await http.get(`/formulaire/distributions/${distributionId}/responses/multiple`, { params: questionIds }));
             return data.map((rr: IResponseResponse) => new Response().build(rr));
         } catch (err) {
@@ -100,9 +101,7 @@ export const responseService: ResponseService = {
     },
 
     async saveMultiple(mapQuestionResponsesToSave: Map<Question, Response[]>, distributionId: number) : Promise<Response[]> {
-        if (!mapQuestionResponsesToSave || mapQuestionResponsesToSave.size <= 0) {
-            return [];
-        }
+        if (!mapQuestionResponsesToSave || mapQuestionResponsesToSave.size <= 0) return [];
 
         let  responsesToUpdate: Response[] = [];
         let responsesToCreate: Response[] = [];
@@ -135,9 +134,7 @@ export const responseService: ResponseService = {
 
     async createMultiple(distributionId: number, responses: Response[]) : Promise<Response[]> {
         try {
-            if (!responses || responses.length <= 0) {
-                return [];
-            }
+            if (!responses || responses.length <= 0) return [];
             let data: IResponseResponse[] = DataUtils.getData(await http.post(`/formulaire/distributions/${distributionId}/responses/multiple`, responses));
             return data.map((rr: IResponseResponse) => new Response().build(rr));
         } catch (err) {
@@ -157,9 +154,7 @@ export const responseService: ResponseService = {
 
     async updateMultiple(distributionId: number, responses: Response[]) : Promise<Response[]> {
         try {
-            if (!responses || responses.length <= 0) {
-                return [];
-            }
+            if (!responses || responses.length <= 0) return [];
             let data: IResponseResponse[] = DataUtils.getData(await http.put(`/formulaire/distributions/${distributionId}/responses`, responses));
             return data.map((rr: IResponseResponse) => new Response().build(rr));
         } catch (err) {
@@ -188,9 +183,7 @@ export const responseService: ResponseService = {
 
     async deleteMultipleByQuestionAndDistribution(questionIds: number[], distributionId: number) : Promise<any> {
         try {
-            if (!questionIds || questionIds.length <= 0) {
-                return [];
-            }
+            if (!questionIds || questionIds.length <= 0) return [];
             return DataUtils.getData(await http.delete(`/formulaire/responses/${distributionId}/questions`, { data: questionIds }));
         } catch (e) {
             notify.error(idiom.translate('formulaire.error.responseService.delete'));


### PR DESCRIPTION
## Describe your changes
When calling some enpoints we use some lists as params. When the list is empty we now immediately return an empty list.

## Checklist tests
- Create a form
- Create some questions without any choices
- Reorganize elements with the dedicated pop up
- When saving it was displaying an error that should not exist anymore

## Issue ticket number and link
FOR-804 : https://jira.support-ent.fr/browse/FOR-804

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)