### PR TITLE
refacto(progress-bar): [#FOR-808] improve calculations for progress-bar display

### DIFF
--- a/common/src/main/resources/ts/directives/progress-bar.ts
+++ b/common/src/main/resources/ts/directives/progress-bar.ts
@@ -18,9 +18,9 @@ export const progressBubbleBar: Directive = ng.directive('progressBubbleBar', ()
         controllerAs: 'vm',
         bindToController: true,
         template: `
-            <div class="progressbar-container" ng-if="vm.longestPath > 0">
+            <div class="progressbar-container">
                 <ul class="progressbar six twelve-mobile">
-                    <li ng-repeat="n in [].constructor(vm.longestPath) track by $index"
+                    <li ng-repeat="n in [].constructor(vm.historicPosition.length + vm.longestPath) track by $index"
                     ng-class="{ active: $index+1 <= vm.historicPosition.length }"></li>
                 </ul>
             </div>

--- a/formulaire-public/src/main/resources/public/template/containers/recap.html
+++ b/formulaire-public/src/main/resources/public/template/containers/recap.html
@@ -15,7 +15,7 @@
             <div ng-repeat="formElement in vm.formElements.all | orderBy:'position'">
 
                 <!-- Display question -->
-                <public-recap-question-item ng-if="FormElementUtils.isQuestion(formElement)"
+                <public-recap-question-item ng-if="formElement.isQuestion()"
                                             question="formElement"
                                             responses="vm.responses"
                                             form-elements="vm.formElements"
@@ -23,7 +23,7 @@
                 </public-recap-question-item>
 
                 <!-- Display section -->
-                <div class="section" ng-if="!FormElementUtils.isQuestion(formElement)">
+                <div class="section" ng-if="formElement.isSection()">
                     <div class="section-top">
                         <div class="title"><h4>[[formElement.title]]</h4></div>
                         <div class="description" ng-if="formElement.description">

--- a/formulaire-public/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire-public/src/main/resources/public/template/containers/respond-question.html
@@ -15,17 +15,17 @@
         <div class="nine twelve-mobile">
 
             <!-- Display question -->
-            <public-question-item ng-if="FormElementUtils.isQuestion(vm.formElement) && vm.formElement.question_type != Types.MATRIX"
+            <public-question-item ng-if="vm.formElement.isQuestion() && vm.formElement.question_type != Types.MATRIX"
                                   question="vm.formElement"
                                   responses="vm.allResponsesInfos.get(vm.formElement).get(vm.formElement)">
             </public-question-item>
-            <public-respond-matrix ng-if="FormElementUtils.isQuestion(vm.formElement) && vm.formElement.question_type == Types.MATRIX"
+            <public-respond-matrix ng-if="vm.formElement.isQuestion() && vm.formElement.question_type == Types.MATRIX"
                            question="vm.formElement"
                            responses="vm.allResponsesInfos.get(vm.formElement).get(vm.formElement)">
             </public-respond-matrix>
 
             <!-- Display section -->
-            <div class="section" ng-if="!FormElementUtils.isQuestion(vm.formElement)">
+            <div class="section" ng-if="vm.formElement.isSection()">
                 <div class="section-top">
                     <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                     <div class="description" ng-if="vm.formElement.description">

--- a/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire-public/src/main/resources/public/ts/controllers/respond-question.ts
@@ -25,6 +25,7 @@ interface ViewModel {
 	longestPath: number;
 	historicPosition: number[];
 	isProcessing: boolean;
+	longestPathsMap: Map<string, number>;
 
 	$onInit(): Promise<void>;
 	prev() : void;
@@ -49,7 +50,8 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 		syncWithStorageData();
 		let formElementPosition = vm.historicPosition[vm.historicPosition.length - 1];
 		vm.formElement = vm.formElements.all[formElementPosition - 1];
-		vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+		vm.longestPathsMap = FormElementUtils.getLongestPaths(vm.formElements);
+		vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
 		initFormElementResponses();
 		$scope.safeApply();
 	}
@@ -62,7 +64,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			let isCursorAgain: boolean = vm.formElement.isSameQuestionTypeOfType(vm.formElements.all[prevPosition - 1], Types.CURSOR);
 			vm.formElement = vm.formElements.all[prevPosition - 1];
 			vm.historicPosition.pop();
-			vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+			vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
 			goToFormElement(isCursorAgain);
 		}
 		vm.isProcessing = false;
@@ -77,7 +79,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
 			let isCursorAgain: boolean = vm.formElement.isSameQuestionTypeOfType(vm.formElements.all[nextPosition - 1], Types.CURSOR);
 			vm.formElement = vm.formElements.all[nextPosition - 1];
 			vm.historicPosition.push(vm.formElement.position);
-			vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+			vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
 			vm.isProcessing = false;
 			goToFormElement(isCursorAgain);
 		}

--- a/formulaire/src/main/resources/public/template/containers/edit-form.html
+++ b/formulaire/src/main/resources/public/template/containers/edit-form.html
@@ -40,7 +40,7 @@
             <div id="container-0" class="elements nested-container" ng-if="!isMobile && vm.formElements.selected.length == 0 && vm.form.nb_responses <= 0">
                 <div ng-repeat="formElement in vm.formElements.all | orderBy:'position'" class="twelve twelve-mobile">
                     <!--  Question component -->
-                    <question-item ng-if="FormElementUtils.isQuestion(formElement)"
+                    <question-item ng-if="formElement.isQuestion()"
                                    question="formElement"
                                    reorder="true"
                                    has-form-responses="vm.form.nb_responses > 0"
@@ -48,7 +48,7 @@
                                    form="vm.form">
                     </question-item>
                     <!--  Section component -->
-                    <section-item ng-if="!FormElementUtils.isQuestion(formElement)"
+                    <section-item ng-if="formElement.isSection()"
                                   section="formElement"
                                   reorder="true"
                                   has-form-responses="vm.form.nb_responses > 0"
@@ -62,7 +62,7 @@
 
                 <div ng-repeat="formElement in vm.formElements.all | orderBy:'position'" class="twelve twelve-mobile">
                     <!--  Question component -->
-                    <question-item ng-if="FormElementUtils.isQuestion(formElement)"
+                    <question-item ng-if="formElement.isQuestion()"
                                    question="formElement"
                                    reorder="false"
                                    has-form-responses="vm.form.nb_responses > 0"
@@ -70,7 +70,7 @@
                                    form="vm.form">
                     </question-item>
                     <!--  Section component -->
-                    <section-item ng-if="!FormElementUtils.isQuestion(formElement)"
+                    <section-item ng-if="formElement.isSection()"
                                   section="formElement"
                                   reorder="false"
                                   has-form-responses="vm.form.nb_responses > 0"

--- a/formulaire/src/main/resources/public/template/containers/preview-form.html
+++ b/formulaire/src/main/resources/public/template/containers/preview-form.html
@@ -35,20 +35,20 @@
     <div class="nine twelve-mobile top-spacing-three" ng-if="vm.preview.page == vm.PreviewPage.QUESTION">
 
         <!-- Display question -->
-        <respond-question-item ng-if="FormElementUtils.isQuestion(vm.preview.formElement) && vm.preview.formElement.question_type != Types.MATRIX"
+        <respond-question-item ng-if="vm.preview.formElement.isQuestion() && vm.preview.formElement.question_type != Types.MATRIX"
                                question="vm.preview.formElement"
                                responses="vm.preview.currentResponses.get(vm.preview.formElement)"
                                distribution="null"
                                files="vm.preview.currentFiles.get(vm.preview.formElement)">
         </respond-question-item>
-        <respond-matrix ng-if="FormElementUtils.isQuestion(vm.preview.formElement) && vm.preview.formElement.question_type == Types.MATRIX"
+        <respond-matrix ng-if="vm.preview.formElement.isQuestion() && vm.preview.formElement.question_type == Types.MATRIX"
                         question="vm.preview.formElement"
                         responses="vm.preview.currentResponses.get(vm.preview.formElement)"
                         distribution="null">
         </respond-matrix>
 
         <!-- Display section -->
-        <div class="section" ng-if="!FormElementUtils.isQuestion(vm.preview.formElement)">
+        <div class="section" ng-if="vm.preview.formElement.isSection()">
             <div class="section-top">
                 <div class="title"><h4>[[vm.preview.formElement.title]]</h4></div>
                 <div class="description" ng-if="vm.preview.formElement.description">

--- a/formulaire/src/main/resources/public/template/containers/recap-questions.html
+++ b/formulaire/src/main/resources/public/template/containers/recap-questions.html
@@ -24,7 +24,7 @@
             <div ng-repeat="formElement in vm.formElements.all | orderBy:'position'">
 
                 <!-- Display question -->
-                <recap-question-item ng-if="FormElementUtils.isQuestion(formElement)"
+                <recap-question-item ng-if="formElement.isQuestion()"
                                      question="formElement"
                                      responses="vm.responses"
                                      form="vm.form"
@@ -34,7 +34,7 @@
                 </recap-question-item>
 
                 <!-- Display section -->
-                <div class="section" ng-if="!FormElementUtils.isQuestion(formElement)">
+                <div class="section" ng-if="formElement.isSection()">
                     <div class="section-top">
                         <div class="title"><h4>[[formElement.title]]</h4></div>
                         <div class="description" ng-if="formElement.description">

--- a/formulaire/src/main/resources/public/template/containers/respond-question.html
+++ b/formulaire/src/main/resources/public/template/containers/respond-question.html
@@ -21,20 +21,20 @@
         <div class="nine twelve-mobile">
 
             <!-- Display question -->
-            <respond-question-item ng-if="FormElementUtils.isQuestion(vm.formElement) && vm.formElement.question_type != Types.MATRIX && vm.currentResponses.get(vm.formElement).hasLoaded"
+            <respond-question-item ng-if="vm.formElement.isQuestion() && vm.formElement.question_type != Types.MATRIX && vm.currentResponses.get(vm.formElement).hasLoaded"
                                    question="vm.formElement"
                                    responses="vm.currentResponses.get(vm.formElement)"
                                    distribution="vm.distribution"
                                    files="vm.currentFiles.get(vm.formElement)">
             </respond-question-item>
-            <respond-matrix ng-if="FormElementUtils.isQuestion(vm.formElement) && vm.formElement.question_type == Types.MATRIX"
+            <respond-matrix ng-if="vm.formElement.isQuestion() && vm.formElement.question_type == Types.MATRIX"
                             question="vm.formElement"
                             responses="vm.currentResponses.get(vm.formElement)"
                             distribution="vm.distribution">
             </respond-matrix>
 
             <!-- Display section -->
-            <div class="section" ng-if="!FormElementUtils.isQuestion(vm.formElement)">
+            <div class="section" ng-if="vm.formElement.isSection()">
                 <div class="section-top">
                     <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                     <div class="description" ng-if="vm.formElement.description">

--- a/formulaire/src/main/resources/public/template/containers/results-form.html
+++ b/formulaire/src/main/resources/public/template/containers/results-form.html
@@ -21,13 +21,13 @@
     <div class="result-element">
 
         <!-- Display question -->
-        <result-question-item ng-if="FormElementUtils.isQuestion(vm.formElement) && (!vm.loading || vm.display.lightbox.export)"
+        <result-question-item ng-if="vm.formElement.isQuestion() && (!vm.loading || vm.display.lightbox.export)"
                               question="vm.formElement"
                               form="vm.form">
         </result-question-item>
 
         <!-- Display section -->
-        <div class="section" ng-if="!FormElementUtils.isQuestion(formElement) && (!vm.loading || vm.display.lightbox.export)">
+        <div class="section" ng-if="vm.formElement.isSection() && (!vm.loading || vm.display.lightbox.export)">
             <div class="section-top">
                 <div class="title"><h4>[[vm.formElement.title]]</h4></div>
                 <div class="description" ng-if="vm.formElement.description">

--- a/formulaire/src/main/resources/public/template/lightbox/questions-reorganization.html
+++ b/formulaire/src/main/resources/public/template/lightbox/questions-reorganization.html
@@ -4,20 +4,20 @@
         <ul id="orga-container-0" class="orga-nested-container">
             <li class="row" ng-repeat="formElement in vm.formElements.all | orderBy:'position'">
                 <!-- Display Question -->
-                <element-item-organization ng-if="FormElementUtils.isQuestion(formElement)"
+                <element-item-organization ng-if="formElement.isQuestion()"
                                            form-element="formElement"
                                            is-section-child="false"
                                            is-first="formElement.position == 1"
                                            is-last="formElement.position == vm.formElements.all.length">
                 </element-item-organization>
                 <!-- Display Section -->
-                <element-item-organization ng-if="!FormElementUtils.isQuestion(formElement)" class="section-orga"
+                <element-item-organization ng-if="formElement.isSection()" class="section-orga"
                                            form-element="formElement"
                                            is-section-child="false"
                                            is-first="formElement.position == 1"
                                            is-last="formElement.position == vm.formElements.all.length">
                 </element-item-organization>
-                <ul id="orga-container-[[formElement.id]]" class="orga-nested-container" ng-if="!FormElementUtils.isQuestion(formElement)">
+                <ul id="orga-container-[[formElement.id]]" class="orga-nested-container" ng-if="formElement.isSection()">
                     <li class="row" ng-repeat="question in formElement.questions.all | orderBy:'section_position'">
                         <element-item-organization form-element="question"
                                                    is-section-child="true"

--- a/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/respond-question.ts
@@ -30,6 +30,7 @@ interface ViewModel {
     currentResponses: Map<Question, Responses>;
     currentFiles: Map<Question, Files>;
     isProcessing: boolean;
+    longestPathsMap: Map<string, number>;
 
     $onInit() : Promise<void>;
     prev() : Promise<void>;
@@ -66,7 +67,9 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
         vm.formElement = vm.formElements.all[$scope.responsePosition - 1];
         vm.nbFormElements = vm.formElements.all.length;
         vm.historicPosition = $scope.historicPosition.length > 0 ? $scope.historicPosition : [1];
-        vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+        vm.longestPathsMap = FormElementUtils.getLongestPaths(vm.formElements);
+        console.log(vm.longestPathsMap);
+        vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
         await initFormElementResponses();
         window.setTimeout(() => vm.loading = false,500);
         $scope.safeApply();
@@ -183,7 +186,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
             await saveResponses();
             vm.formElement = vm.formElements.all[prevPosition - 1];
             vm.historicPosition.pop();
-            vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+            vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
             goToFormElement();
         }
         vm.isProcessing = false;
@@ -201,7 +204,7 @@ export const respondQuestionController = ng.controller('RespondQuestionControlle
             await saveResponses();
             vm.formElement = vm.formElements.all[nextPosition - 1];
             vm.historicPosition.push(vm.formElement.position);
-            vm.longestPath = vm.historicPosition.length + FormElementUtils.findLongestPathInFormElement(vm.formElement.id, vm.formElements) - 1;
+            vm.longestPath = vm.formElement.getCurrentLongestPath(vm.longestPathsMap);
             vm.isProcessing = false;
             goToFormElement();
         }


### PR DESCRIPTION
## Describe your changes
The progress-bar shows to the user the number of questions already answered and the number remaining if continuing this flow of responses.
Before, these numbers were calculated at each page of response, according the selected flow.
But these flow are fixed from the begining so now we do all the calculation, store them in a map and simply get the corresponding value when navigating between pages.

## Checklist tests

## Issue ticket number and link
FOR-808 : https://jira.support-ent.fr/browse/FOR-808

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)