### PR TITLE
fix(progress-bar): [#FOR-807] wait elements saving before displaying pop up for a new one

### DIFF
--- a/formulaire/src/main/resources/public/template/lightbox/new-element.html
+++ b/formulaire/src/main/resources/public/template/lightbox/new-element.html
@@ -1,23 +1,30 @@
 <lightbox class="new-element dontSave" show="vm.display.lightbox.newElement" on-close="vm.closeLightbox('newElement')">
     <h2><i18n>formulaire.element.new.title</i18n></h2>
-    <div class="section" ng-click="vm.doCreateNewElement()" ng-if="!vm.parentSection">
-        <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
-        <div><i18n>formulaire.element.new.section.description</i18n></div>
-    </div>
-    <div class="question">
-        <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
-        <div class="dominos">
-            <div ng-repeat="type in vm.questionTypes.all" class="item"
-                 ng-click="vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
-                <div class="domino">
-                    <div class="data-text">
-                        <h5>[[vm.displayTypeName(type.name)]]</h5>
-                    </div>
-                    <div class="picture">
-                        <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
+    <div  ng-if="!vm.isProcessing">
+        <div class="section" ng-click="vm.isProcessing || vm.doCreateNewElement()" ng-if="!vm.parentSection">
+            <div class="subtitle"><i18n>formulaire.element.new.section.title</i18n></div>
+            <div><i18n>formulaire.element.new.section.description</i18n></div>
+        </div>
+        <div class="question">
+            <div class="subtitle"><i18n>formulaire.element.new.question.title</i18n></div>
+            <div class="dominos">
+                <div ng-repeat="type in vm.questionTypes.all" class="item"
+                     ng-click="vm.isProcessing || vm.doCreateNewElement(type.code, vm.parentSection)" title="[[vm.displayTypeDescription(type.name)]]">
+                    <div class="domino">
+                        <div class="data-text">
+                            <h5>[[vm.displayTypeName(type.name)]]</h5>
+                        </div>
+                        <div class="picture">
+                            <img ng-src="[[(vm.iconUtils.displayTypeIcon(type.code)) || '/formulaire/public/img/empty-image.png']]"/>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
+
+    <!-- Loader -->
+    <div ng-if="vm.isProcessing" class="twelve loader">
+        <loader min-height="'10px'"/>
     </div>
 </lightbox>

--- a/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
+++ b/formulaire/src/main/resources/public/ts/controllers/form-editor.ts
@@ -33,7 +33,6 @@ import * as Sortable from "sortablejs";
 import {FormElementUtils, UtilsUtils} from "@common/utils";
 import {Constants} from "@common/core/constants";
 import {PropPosition} from "@common/core/enums/prop-position";
-import {FormElementType} from "@common/core/enums/form-element-type";
 import {IconUtils} from "@common/utils/icon";
 
 enum PreviewPage { RGPD = 'rgpd', QUESTION = 'question', RECAP = 'recap'}
@@ -65,7 +64,6 @@ interface ViewModel {
     PreviewPage: typeof PreviewPage;
     nestedSortables: any[];
     iconUtils: IconUtils;
-    initializing: boolean;
     isProcessing: boolean;
 
     $onInit() : Promise<void>;
@@ -122,7 +120,6 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         vm.iconUtils = IconUtils;
 
         vm.$onInit = async () : Promise<void> => {
-            vm.initializing = true;
             vm.form = $scope.form;
             vm.form.nb_responses = vm.form.id ? (await distributionService.count(vm.form.id)).count : 0;
             await vm.formElements.sync(vm.form.id);
@@ -132,7 +129,6 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
             $scope.safeApply();
 
             initNestedSortables();
-            vm.initializing = false;
             $scope.safeApply();
         };
 
@@ -207,9 +203,11 @@ export const formEditorController = ng.controller('FormEditorController', ['$sco
         };
 
         vm.createNewElement = async (parentSection?) : Promise<void> => {
+            vm.isProcessing = true;
             vm.parentSection = parentSection ? parentSection : null;
             template.open('lightbox', 'lightbox/new-element');
             vm.display.lightbox.newElement = true;
+            vm.isProcessing = false;
             $scope.safeApply();
         };
 


### PR DESCRIPTION
## Describe your changes
We add a loader to a pop up to wait that all the form elements are saved before displaying anything

## Checklist tests

## Issue ticket number and link
FOR-807 : https://jira.support-ent.fr/browse/FOR-807

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)