### PR TITLE
fix(reorganization): [#FOR-810] add checks before saving when drag and drop elements

### DIFF
--- a/formulaire/src/main/resources/i18n/en.json
+++ b/formulaire/src/main/resources/i18n/en.json
@@ -220,6 +220,7 @@
   "formulaire.section.missing.field.title": "Attention, la section ci-dessus nécessite un titre pour être valide.",
   "formulaire.section.missing.field.choice": "Attention, la section ci-dessus nécessite au moins un choix pour être valide.",
   "formulaire.section.save.missing.field": "Attention, certaines sections manquent d'informations pour être valides !",
+  "formulaire.section.save.multiple.conditional" : "Attention, une section ne doit comporter qu'une question conditionnelle pour être valide",
   "formulaire.question.save.image.missing.field": "Attention, le choix ne peut pas comporter une image seule. Veuillez saisir du texte.",
   "formulaire.question.save.images.missing.fields": "Attention, les choix ne peuvent pas comporter une image seule. Veuillez saisir du texte.",
   "formulaire.element.block.multiple.conditional" : "Attention, la section ci-dessus ne doit comporter qu'une question conditionnelle pour être valide",

--- a/formulaire/src/main/resources/i18n/fr.json
+++ b/formulaire/src/main/resources/i18n/fr.json
@@ -221,6 +221,7 @@
   "formulaire.section.missing.field.title": "Attention, la section ci-dessus nécessite un titre pour être valide.",
   "formulaire.section.missing.field.choice": "Attention, la section ci-dessus nécessite au moins un choix pour être valide.",
   "formulaire.section.save.missing.field": "Attention, certaines sections manquent d'informations pour être valides !",
+  "formulaire.section.save.multiple.conditional" : "Attention, une section ne doit comporter qu'une question conditionnelle pour être valide",
   "formulaire.question.save.image.missing.field": "Attention, le choix ne peut pas comporter une image seule. Veuillez saisir du texte.",
   "formulaire.question.save.images.missing.fields": "Attention, les choix ne peuvent pas comporter une image seule. Veuillez saisir du texte.",
   "formulaire.element.block.multiple.conditional" : "Attention, la section ci-dessus ne doit comporter qu'une question conditionnelle pour être valide",

--- a/formulaire/src/main/resources/public/ts/directives/section-item/section-item.directive.ts
+++ b/formulaire/src/main/resources/public/ts/directives/section-item/section-item.directive.ts
@@ -28,6 +28,7 @@ interface IViewModel extends ng.IController, ISectionItemProps {
     addQuestionToSection(): Promise<void>;
     addQuestionToSectionGuard(): void;
     hasConditional() : boolean;
+    hasSeveralConditionals(): boolean;
     filterNextElements(formElement: FormElement): boolean;
     onSelectOption(): Promise<void>;
 }
@@ -100,6 +101,10 @@ class Controller implements IViewModel {
 
     hasConditional = (): boolean => {
         return this.section.questions.all.filter((q: Question) => q.conditional).length > 0;
+    }
+
+    hasSeveralConditionals = () : boolean => {
+        return this.section.questions.all.filter((q: Question) => q.conditional).length >= 2;
     }
 
     filterNextElements = (formElement: FormElement) : boolean => {

--- a/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
+++ b/formulaire/src/main/resources/public/ts/directives/section-item/section-item.html
@@ -91,5 +91,5 @@
     </div>
 
     <div class="warning" ng-if="!vm.section.title"><i18n>formulaire.section.missing.field.title</i18n></div>
-    <div class="warning" ng-if="vm.verifConditional()"><i18n>formulaire.element.block.multiple.conditional</i18n></div>
+    <div class="warning" ng-if="vm.hasSeveralConditionals()"><i18n>formulaire.element.block.multiple.conditional</i18n></div>
 </div>


### PR DESCRIPTION
## Describe your changes
When saving form elements on drag and drop (form editor view or reorgnaization pop up) we now do some more checks to avoid cases like two conditionnal in a section or things like that

## Checklist tests

## Issue ticket number and link
FOR-810 : https://jira.support-ent.fr/browse/FOR-810

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)