### PR TITLE
feat(colors): [#FOR-549] make graph colors constant

### DIFF
--- a/common/src/main/resources/ts/core/constants/constants.ts
+++ b/common/src/main/resources/ts/core/constants/constants.ts
@@ -8,12 +8,22 @@ export abstract class Constants {
     static readonly MAX_FILES_SAVE: number = 10;
 
     // Colors
-    static readonly GRAPH_COLORS: string[] = ['#37A4CD','#1691C0','#056F98','#5AB7DA','#89CEE9'];
+    private static getGraphColors = (colorsGroups: Array<string[]>) : string[] => {
+        let colors: string[] = [];
+        let nbColorPerGroup: number = colorsGroups[0].length || 0;
+        for (let i = 0; i < nbColorPerGroup; i++) {
+            for (let groupColor of colorsGroups) {
+                colors.push(groupColor[i]);
+            }
+        }
+        return colors;
+    }
     static readonly BLUE_COLORS: string[] = ['#37A4CD','#1691C0','#056F98','#5AB7DA','#89CEE9'];
     static readonly YELLOW_COLORS: string[] = ['#FFC73C','#F2AE00','#FFBB13','#FFD263','#FFDF91'];
     static readonly PURPLE_COLORS: string[] = ['#475DD5','#1129A6','#2741C9','#687BE0','#93A1EC'];
     static readonly ORANGE_COLORS: string[] = ['#FFA23C','#F27E00','#FF8E13','#FFB463','#FFCA91'];
     static readonly COLORS_GROUPS: Array<string[]> = [Constants.BLUE_COLORS, Constants.YELLOW_COLORS, Constants.PURPLE_COLORS, Constants.ORANGE_COLORS];
+    static readonly GRAPH_COLORS: string[] = this.getGraphColors(this.COLORS_GROUPS);
     static readonly NB_COLORS_AVAILABLE: number = 25;
 
     // Dates format
@@ -23,5 +33,4 @@ export abstract class Constants {
     // Types
     static readonly STRING: string = "string";
     static readonly FILE: string = "file";
-
 }

--- a/common/src/main/resources/ts/utils/graph.ts
+++ b/common/src/main/resources/ts/utils/graph.ts
@@ -2,6 +2,7 @@ import {idiom, idiom as lang} from 'entcore';
 import {Question, QuestionChoice, Response, Types} from "@common/models";
 import {ColorUtils} from "@common/utils/color";
 import ApexCharts from 'apexcharts';
+import {Constants} from "@common/core/constants";
 
 export class GraphUtils {
 
@@ -61,7 +62,7 @@ export class GraphUtils {
         // Generate options with labels and colors
         let baseHeight: number = 40 * question.choices.all.length;
         let height: number = baseHeight < 200 ? 200 : (baseHeight > 500 ? 500 : baseHeight);
-        let colors: string[] = ColorUtils.generateColorList(labels.length);
+        let colors: string[] = Constants.GRAPH_COLORS;
         let newOptions: any = isExportPDF ?
             GraphUtils.generateOptions(question.question_type, colors, labels) :
             GraphUtils.generateOptions(question.question_type, colors, labels, height, '100%');
@@ -99,7 +100,7 @@ export class GraphUtils {
         }
 
         // Generate options with labels and colors
-        let colors: string[] = ColorUtils.generateColorList(series.length);
+        let colors: string[] = Constants.GRAPH_COLORS;
 
         let newOptions: any = isExportPDF ?
             GraphUtils.generateOptions(question.question_type, colors, labels, null, null) :
@@ -127,7 +128,7 @@ export class GraphUtils {
             acc.set(e, (acc.get(e) || 0) + 1), new Map());
 
         let labels: number[] = Array.from(map.keys());
-        let colors: string[] = ColorUtils.generateColorList(labels.length);
+        let colors: string[] = Constants.GRAPH_COLORS;
 
         let newPDFOptions: any = isExportPDF ?
             GraphUtils.generateOptions(question.question_type, colors, labels, null, null) :
@@ -184,7 +185,7 @@ export class GraphUtils {
             series.push(seriesOptions);
         });
 
-        let colors: string[] = ColorUtils.generateColorList(choices.length);
+        let colors: string[] = Constants.GRAPH_COLORS;
         let newOptions: any = isExportPDF ?
             GraphUtils.generateOptions(question.question_type, colors, labels, null, null) :
             GraphUtils.generateOptions(question.question_type, colors, labels, '100%', '100%');
@@ -222,7 +223,7 @@ export class GraphUtils {
 
         let baseHeight: number = 50 * choices.length;
         let height: number = baseHeight < 200 ? 200 : (baseHeight > 500 ? 500 : baseHeight);
-        let colors: string[] = ColorUtils.generateColorList(labels.length);
+        let colors: string[] = Constants.GRAPH_COLORS;
         let newOptions: any = GraphUtils.generateOptions(question.question_type, colors, labels, height, null);
         newOptions.series = [{ data: series }];
 

--- a/formulaire/src/main/resources/public/ts/directives/question/result-question-item/result-question-item.directive.ts
+++ b/formulaire/src/main/resources/public/ts/directives/question/result-question-item/result-question-item.directive.ts
@@ -9,11 +9,12 @@ import {
     Responses,
     Types
 } from "@common/models";
-import {ColorUtils, DateUtils} from "@common/utils";
+import {DateUtils} from "@common/utils";
 import {GraphUtils} from "@common/utils/graph";
 import {IScope} from "angular";
 import {RootsConst} from "../../../core/constants/roots.const";
 import {FORMULAIRE_FORM_ELEMENT_EMIT_EVENT} from "@common/core/enums";
+import {Constants} from "@common/core/constants";
 
 interface IResultQuestionItemScopeProps {
     question: Question;
@@ -101,7 +102,7 @@ class Controller implements ng.IController, IViewModel {
             if (this.isGraphQuestion) {
                 if (this.question.canHaveCustomAnswers()) this.syncResultsMap();
                 this.question.fillChoicesInfo(this.distributions, this.responses.all);
-                this.colors = ColorUtils.generateColorList(this.question.choices.all.length);
+                this.colors = Constants.GRAPH_COLORS;
                 await this.generateChart();
             }
             else {


### PR DESCRIPTION
## Describe your changes
Graph colors where previously generated semi-randomly every time a graph was displayed.
Now our 25 colors are ordered in a specific order and graphs always use these colors in these specific order.

## Checklist tests

## Issue ticket number and link
FOR-549 : https://jira.support-ent.fr/browse/FOR-549

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)