### PR TITLE
fix: WB-2579, enrich form dates with timezone offset

### DIFF
--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -141,7 +141,7 @@ public class FormController extends ControllerHelper {
                     })
                     .onFailure(error -> {
                         String errorMessage = "[Formulaire@listForms] Failed retrieving the forms : " + error.getMessage();
-                        Renders.log.error(errorMessage);
+                        log.error(errorMessage);
                         Renders.renderJson(request, new JsonObject().put("error", errorMessage), 400);
                     });
         });

--- a/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/controllers/FormController.java
@@ -13,6 +13,7 @@ import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.http.Renders;
 import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -134,7 +135,15 @@ public class FormController extends ControllerHelper {
             if (user.getGroupsIds() != null) {
                 groupsAndUserIds.addAll(user.getGroupsIds());
             }
-            formService.list(groupsAndUserIds, user, arrayResponseHandler(request));
+            formService.list(groupsAndUserIds, user)
+                    .onSuccess(forms -> {
+                        Renders.renderJson(request, forms);
+                    })
+                    .onFailure(error -> {
+                        String errorMessage = "[Formulaire@listForms] Failed retrieving the forms : " + error.getMessage();
+                        Renders.log.error(errorMessage);
+                        Renders.renderJson(request, new JsonObject().put("error", errorMessage), 400);
+                    });
         });
     }
 

--- a/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/FormService.java
@@ -17,9 +17,8 @@ public interface FormService {
      * List all forms created by me or shared with me
      * @param groupsAndUserIds list of neo ids including the connected user
      * @param user user connected
-     * @param handler function handler returning JsonArray data
      */
-    void list(List<String> groupsAndUserIds, UserInfos user, Handler<Either<String, JsonArray>> handler);
+    Future<JsonArray> list(List<String> groupsAndUserIds, UserInfos user);
 
     /**
      * @deprecated Should use {@link #listByIds(JsonArray)} instead

--- a/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
+++ b/formulaire/src/main/java/fr/openent/formulaire/service/impl/DefaultFormService.java
@@ -4,12 +4,16 @@ import fr.openent.form.core.enums.I18nKeys;
 import fr.openent.form.core.models.Form;
 import fr.openent.form.core.models.ShareMember;
 import fr.openent.form.core.models.TransactionElement;
-import fr.openent.form.helpers.*;
+import fr.openent.form.helpers.FutureHelper;
+import fr.openent.form.helpers.I18nHelper;
+import fr.openent.form.helpers.IModelHelper;
+import fr.openent.form.helpers.TransactionHelper;
 import fr.openent.formulaire.service.FormService;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -21,6 +25,9 @@ import org.entcore.common.user.UserInfos;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 import static fr.openent.form.core.constants.Constants.*;
@@ -38,9 +45,11 @@ public class DefaultFormService implements FormService {
     private final Sql sql = Sql.getInstance();
     private final SimpleDateFormat dateFormatter1 = new SimpleDateFormat(YYYY_MM_DD_T_HH_MM_SS_SSS);
     private final SimpleDateFormat dateFormatter2 = new SimpleDateFormat(EEE_MMM_DD_HH_MM_SS_Z_YYYY);
+    private final Set<String> dateFieldsToFormat = new HashSet<>(Arrays.asList("date_creation", "date_modification", "date_opening", "date_ending"));
 
     @Override
-    public void list(List<String> groupsAndUserIds, UserInfos user, Handler<Either<String, JsonArray>> handler) {
+    public Future<JsonArray> list(List<String> groupsAndUserIds, UserInfos user) {
+        Promise<JsonArray> formsPromise = Promise.promise();
         StringBuilder query = new StringBuilder();
         JsonArray params = new JsonArray();
 
@@ -66,7 +75,21 @@ public class DefaultFormService implements FormService {
                 .append("ORDER BY f.date_modification DESC;");
         params.add(MANAGER_RESOURCE_BEHAVIOUR).add(CONTRIB_RESOURCE_BEHAVIOUR).add(user.getUserId());
 
-        Sql.getInstance().prepared(query.toString(), params, SqlResult.validResultHandler(handler));
+        Sql.getInstance().prepared(query.toString(), params, new DeliveryOptions())
+                .onSuccess(sqlResponseMessage -> {
+                    Either<String, JsonArray> sqlResult = SqlResult.validResult(sqlResponseMessage);
+                    if (sqlResult.isLeft()) {
+                        formsPromise.fail(sqlResult.left().getValue());
+                    } else {
+                        JsonArray formattedForms = new JsonArray();
+                        sqlResult.right().getValue().forEach(form -> {
+                            formattedForms.add(formatFormDatesWithTimezone((JsonObject) form));
+                        });
+                        formsPromise.complete(formattedForms);
+                    }
+                })
+                .onFailure(formsPromise::fail);
+		return formsPromise.future();
     }
 
     @Deprecated
@@ -209,8 +232,19 @@ public class DefaultFormService implements FormService {
         JsonArray params = new JsonArray().add(formId).add(user.getUserId()).add(formId);
 
         String errorMessage = "[Formulaire@DefaultFormService::get] Fail to get form with id " + formId;
-        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(FutureHelper.handlerEither(promise, errorMessage)));
-
+        Sql.getInstance().prepared(query, params, new DeliveryOptions())
+                .onSuccess(sqlResponseMessage -> {
+                    Either<String, JsonObject> sqlResult = SqlResult.validUniqueResult(sqlResponseMessage);
+                    if (sqlResult.isLeft()) {
+                        promise.fail(sqlResult.left().getValue());
+                    } else {
+                        promise.complete(formatFormDatesWithTimezone(sqlResult.right().getValue()));
+                    }
+                })
+                .onFailure(error -> {
+                    log.error(errorMessage + error.getMessage());
+                    promise.fail(error.getMessage());
+                });
         return promise.future();
     }
 
@@ -702,5 +736,21 @@ public class DefaultFormService implements FormService {
                 return promise.future();
             }
         }
+    }
+
+    /**
+     * Method enriching form dates with timezone offset of the server.
+     * @param originalForm form whose date fields must be enriched with timezone information
+     * @return form with its date fields enriched with server timezone information
+     */
+    private JsonObject formatFormDatesWithTimezone(JsonObject originalForm) {
+        JsonObject formattedForm = originalForm.copy();
+        dateFieldsToFormat.forEach(dateField -> {
+            if (originalForm.getString(dateField) != null) {
+                OffsetDateTime offsetDateTime = LocalDateTime.parse(formattedForm.getString(dateField)).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+                formattedForm.put(dateField, offsetDateTime.toString());
+            }
+        });
+        return formattedForm;
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,4 @@ vertxCronTimer=2.0.0
 powerMockVersion=2.0.2
 mockitoVersion=2.+
 
-entCoreVersion=5.3-SNAPSHOT
+entCoreVersion=5.3-b2school-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,4 @@ vertxCronTimer=2.0.0
 powerMockVersion=2.0.2
 mockitoVersion=2.+
 
-entCoreVersion=4.12-SNAPSHOT
+entCoreVersion=5.3-SNAPSHOT


### PR DESCRIPTION
## Describe your changes

Pour que le front puisse recalculer correctement l'heure à afficher selon la timezone côté client, le back doit fournir les dates des formulaires (création, modification) avec les informations de timezone.
Ces informations sont bien persistées en base dans le cas des formulaire, mais l'information est perdue lorsque l'on récupère l'information depuis la base de donnée.
Étant donnés les risques liés au fait de corriger le problème côté mod-postgres (car transverse à toutes les applications utilisant une base Postgres), la solution implémentée consiste à redonner les informations de Timezone du serveur tronquées par mod-postgres, côté application gestionnaire de ressource.

Le cadrage technique est détaillé [ici](https://edifice-community.atlassian.net/wiki/spaces/ODE/pages/3777626144/Gestion+des+Time+zones+-+Qualification+technique#Correction---Formulaire).

## Checklist tests

- Excécution des TU existants : pas de régression
- Tests manuels côté FrontEnd

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/WB-2579

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)