### PR TITLE
fix(placeholder): #FOR-886 remove placeholder from folder modal

### DIFF
--- a/formulaire/frontend/src/containers/FolderModal/index.tsx
+++ b/formulaire/frontend/src/containers/FolderModal/index.tsx
@@ -97,7 +97,6 @@ export const FolderModal: FC<FolderModalProps> = ({
           </Typography>
           <TextField
             variant="standard"
-            placeholder={t("formulaire.question.label")}
             sx={folderModalTextFieldStyle}
             value={newName}
             onChange={(e) => setNewName(e.target.value)}


### PR DESCRIPTION
## Describe your changes
This pull request includes a small change to the `FolderModal` component in the `formulaire/frontend/src/containers/FolderModal/index.tsx` file. The placeholder text for the `TextField` has been removed.

* [`formulaire/frontend/src/containers/FolderModal/index.tsx`](diffhunk://#diff-0e2c3ea69ce7d755c6874df601d7a143b17878b85f7db4a7a4a908a59cc1ef81L100): Removed the placeholder text from the `TextField` component
## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)