### PR TITLE
refactor(i18n): refactor i18n in hooks

### DIFF
--- a/formulaire/frontend/src/containers/HomeMainFormsTable/utils.ts
+++ b/formulaire/frontend/src/containers/HomeMainFormsTable/utils.ts
@@ -1,17 +1,16 @@
-import { useTranslation } from "react-i18next";
 import { IColumn, TablePaginationProps } from "./types";
 import { ColumnId } from "./enums";
-import { DEFAULT_PAGINATION_LIMIT, FORMULAIRE } from "~/core/constants";
+import { DEFAULT_PAGINATION_LIMIT } from "~/core/constants";
 import { IForm } from "~/core/models/form/types";
+import i18n from "~/i18n";
 
 export const useColumns: () => IColumn[] = () => {
-  const { t } = useTranslation(FORMULAIRE);
   return [
     { id: ColumnId.SELECT, label: "", width: "5%" },
-    { id: ColumnId.TITLE, label: t("formulaire.table.title"), width: "30%" },
-    { id: ColumnId.AUTHOR, label: t("formulaire.table.author"), width: "20%" },
-    { id: ColumnId.RESPONSE, label: t("formulaire.table.responses"), width: "10%" },
-    { id: ColumnId.LAST_MODIFICATION, label: t("formulaire.table.modified"), width: "30%" },
+    { id: ColumnId.TITLE, label: i18n.t("formulaire.table.title"), width: "30%" },
+    { id: ColumnId.AUTHOR, label: i18n.t("formulaire.table.author"), width: "20%" },
+    { id: ColumnId.RESPONSE, label: i18n.t("formulaire.table.responses"), width: "10%" },
+    { id: ColumnId.LAST_MODIFICATION, label: i18n.t("formulaire.table.modified"), width: "30%" },
     { id: ColumnId.STATUS, label: "", width: "10%" },
   ];
 };

--- a/formulaire/frontend/src/containers/HomeMainFormsTable/utils.ts
+++ b/formulaire/frontend/src/containers/HomeMainFormsTable/utils.ts
@@ -2,15 +2,15 @@ import { IColumn, TablePaginationProps } from "./types";
 import { ColumnId } from "./enums";
 import { DEFAULT_PAGINATION_LIMIT } from "~/core/constants";
 import { IForm } from "~/core/models/form/types";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useColumns: () => IColumn[] = () => {
   return [
     { id: ColumnId.SELECT, label: "", width: "5%" },
-    { id: ColumnId.TITLE, label: i18n.t("formulaire.table.title"), width: "30%" },
-    { id: ColumnId.AUTHOR, label: i18n.t("formulaire.table.author"), width: "20%" },
-    { id: ColumnId.RESPONSE, label: i18n.t("formulaire.table.responses"), width: "10%" },
-    { id: ColumnId.LAST_MODIFICATION, label: i18n.t("formulaire.table.modified"), width: "30%" },
+    { id: ColumnId.TITLE, label: t("formulaire.table.title"), width: "30%" },
+    { id: ColumnId.AUTHOR, label: t("formulaire.table.author"), width: "20%" },
+    { id: ColumnId.RESPONSE, label: t("formulaire.table.responses"), width: "10%" },
+    { id: ColumnId.LAST_MODIFICATION, label: t("formulaire.table.modified"), width: "30%" },
     { id: ColumnId.STATUS, label: "", width: "10%" },
   ];
 };

--- a/formulaire/frontend/src/containers/HomeMainSentFormTable/index.tsx
+++ b/formulaire/frontend/src/containers/HomeMainSentFormTable/index.tsx
@@ -98,7 +98,7 @@ export const HomeMainSentFormTable: FC<IHomeMainSentFormTableProps> = ({ sentFor
                     variant={TypographyVariant.BODY2}
                     color={isFormFilled(form, distributions) ? SUCCESS_MAIN_COLOR : ERROR_MAIN_COLOR}
                   >
-                    {getFormStatusText(form, getFormDistributions(form, distributions), formatDateWithTime, t)}
+                    {getFormStatusText(form, getFormDistributions(form, distributions), formatDateWithTime)}
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/formulaire/frontend/src/containers/HomeMainSentFormTable/utils.ts
+++ b/formulaire/frontend/src/containers/HomeMainSentFormTable/utils.ts
@@ -1,13 +1,13 @@
 import { IColumn } from "../HomeMainFormsTable/types";
 import { ColumnId } from "../HomeMainFormsTable/enums";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useSentFormColumns: () => IColumn[] = () => {
   return [
     { id: ColumnId.SELECT, label: "", width: "1%" },
-    { id: ColumnId.TITLE, label: i18n.t("formulaire.form.create.title"), width: "12%" },
-    { id: ColumnId.AUTHOR, label: i18n.t("formulaire.table.author"), width: "12%" },
-    { id: ColumnId.SENDING_DATE, label: i18n.t("formulaire.table.sent"), width: "12%" },
-    { id: ColumnId.STATUS, label: i18n.t("formulaire.status"), width: "12%" },
+    { id: ColumnId.TITLE, label: t("formulaire.form.create.title"), width: "12%" },
+    { id: ColumnId.AUTHOR, label: t("formulaire.table.author"), width: "12%" },
+    { id: ColumnId.SENDING_DATE, label: t("formulaire.table.sent"), width: "12%" },
+    { id: ColumnId.STATUS, label: t("formulaire.status"), width: "12%" },
   ];
 };

--- a/formulaire/frontend/src/containers/HomeMainSentFormTable/utils.ts
+++ b/formulaire/frontend/src/containers/HomeMainSentFormTable/utils.ts
@@ -1,15 +1,13 @@
-import { useTranslation } from "react-i18next";
 import { IColumn } from "../HomeMainFormsTable/types";
-import { FORMULAIRE } from "~/core/constants";
 import { ColumnId } from "../HomeMainFormsTable/enums";
+import i18n from "~/i18n";
 
 export const useSentFormColumns: () => IColumn[] = () => {
-  const { t } = useTranslation(FORMULAIRE);
   return [
     { id: ColumnId.SELECT, label: "", width: "1%" },
-    { id: ColumnId.TITLE, label: t("formulaire.form.create.title"), width: "12%" },
-    { id: ColumnId.AUTHOR, label: t("formulaire.table.author"), width: "12%" },
-    { id: ColumnId.SENDING_DATE, label: t("formulaire.table.sent"), width: "12%" },
-    { id: ColumnId.STATUS, label: t("formulaire.status"), width: "12%" },
+    { id: ColumnId.TITLE, label: i18n.t("formulaire.form.create.title"), width: "12%" },
+    { id: ColumnId.AUTHOR, label: i18n.t("formulaire.table.author"), width: "12%" },
+    { id: ColumnId.SENDING_DATE, label: i18n.t("formulaire.table.sent"), width: "12%" },
+    { id: ColumnId.STATUS, label: i18n.t("formulaire.status"), width: "12%" },
   ];
 };

--- a/formulaire/frontend/src/core/models/form/utils.ts
+++ b/formulaire/frontend/src/core/models/form/utils.ts
@@ -4,7 +4,7 @@ import { IFormPayload, IForm } from "./types";
 import { IDistribution } from "../distribution/types";
 import { getFirstDistribution, getLatestDistribution, getNbFinishedDistrib } from "../distribution/utils";
 import { DistributionStatus } from "../distribution/enums";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const buildFormPayload = (
   formPropValue: IFormPropInputValueState,
@@ -86,7 +86,7 @@ export const getFormStatusText = (
 ): string => {
   const formDistributions = getFormDistributions(form, distributions);
   if (form.multiple) {
-    return `${i18n.t("formulaire.responses.count")} : ${getNbFinishedDistrib(formDistributions).toString()}`;
+    return `${t("formulaire.responses.count")} : ${getNbFinishedDistrib(formDistributions).toString()}`;
   } else {
     if (getNbFinishedDistrib(formDistributions) > 0) {
       const latestDistrib = getLatestDistribution(formDistributions);
@@ -94,6 +94,6 @@ export const getFormStatusText = (
         return formatDateWithTime(latestDistrib.dateResponse, "formulaire.responded.date");
       }
     }
-    return i18n.t("formulaire.responded.waiting");
+    return t("formulaire.responded.waiting");
   }
 };

--- a/formulaire/frontend/src/core/models/form/utils.ts
+++ b/formulaire/frontend/src/core/models/form/utils.ts
@@ -4,6 +4,7 @@ import { IFormPayload, IForm } from "./types";
 import { IDistribution } from "../distribution/types";
 import { getFirstDistribution, getLatestDistribution, getNbFinishedDistrib } from "../distribution/utils";
 import { DistributionStatus } from "../distribution/enums";
+import i18n from "~/i18n";
 
 export const buildFormPayload = (
   formPropValue: IFormPropInputValueState,
@@ -82,11 +83,10 @@ export const getFormStatusText = (
   form: IForm,
   distributions: IDistribution[],
   formatDateWithTime: (date: string | Date | undefined, i18nTextKey: string) => string,
-  t: (key: string) => string,
 ): string => {
   const formDistributions = getFormDistributions(form, distributions);
   if (form.multiple) {
-    return `${t("formulaire.responses.count")} : ${getNbFinishedDistrib(formDistributions).toString()}`;
+    return `${i18n.t("formulaire.responses.count")} : ${getNbFinishedDistrib(formDistributions).toString()}`;
   } else {
     if (getNbFinishedDistrib(formDistributions) > 0) {
       const latestDistrib = getLatestDistribution(formDistributions);
@@ -94,6 +94,6 @@ export const getFormStatusText = (
         return formatDateWithTime(latestDistrib.dateResponse, "formulaire.responded.date");
       }
     }
-    return t("formulaire.responded.waiting");
+    return i18n.t("formulaire.responded.waiting");
   }
 };

--- a/formulaire/frontend/src/hook/useFolderSubtitle.ts
+++ b/formulaire/frontend/src/hook/useFolderSubtitle.ts
@@ -1,15 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { useTranslation } from "react-i18next";
-import { FORMULAIRE } from "~/core/constants";
 import { IFolder } from "~/core/models/folder/types";
+import i18n from "~/i18n";
 
 export const useFolderSubtitle = () => {
-  const { t } = useTranslation(FORMULAIRE);
-
   return (folder: IFolder) => {
     const childrenNumbers: string = folder.nb_folder_children.toString();
     const formsNumbers: string = folder.nb_form_children.toString();
-    return t("formulaire.folder.nbItems", {
+    return i18n.t("formulaire.folder.nbItems", {
       0: childrenNumbers,
       1: formsNumbers,
     });

--- a/formulaire/frontend/src/hook/useFolderSubtitle.ts
+++ b/formulaire/frontend/src/hook/useFolderSubtitle.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { IFolder } from "~/core/models/folder/types";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useFolderSubtitle = () => {
   return (folder: IFolder) => {
     const childrenNumbers: string = folder.nb_folder_children.toString();
     const formsNumbers: string = folder.nb_form_children.toString();
-    return i18n.t("formulaire.folder.nbItems", {
+    return t("formulaire.folder.nbItems", {
       0: childrenNumbers,
       1: formsNumbers,
     });

--- a/formulaire/frontend/src/hook/useFormItemsIcons.tsx
+++ b/formulaire/frontend/src/hook/useFormItemsIcons.tsx
@@ -14,7 +14,7 @@ import { useFormatDateWithTime } from "./useFormatDateWithTime";
 import { getFormStatusText, isFormFilled } from "~/core/models/form/utils";
 import { IDistribution } from "~/core/models/distribution/types";
 import { getFirstDistributionDate } from "~/core/models/distribution/utils";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useFormItemsIcons = () => {
   const formatDateWithTime = useFormatDateWithTime();
@@ -48,7 +48,7 @@ export const useFormItemsIcons = () => {
         .filter(({ condition }) => condition)
         // eslint-disable-next-line @typescript-eslint/naming-convention
         .map(({ textKey, IconComponent }) => ({
-          text: i18n.t(textKey),
+          text: t(textKey),
           icon: <IconComponent sx={{ color: (theme) => theme.palette.grey.darker }} />,
         }))
     );
@@ -74,7 +74,7 @@ export const useFormItemsIcons = () => {
         icon: <AssignmentTurnedInIcon sx={{ color: PRIMARY_MAIN_COLOR }} />,
         text: (
           <EllipsisWithTooltip typographyProps={{ color: TEXT_SECONDARY_COLOR }}>
-            {`${(form.nb_responses ?? 0).toString()} ${i18n.t("formulaire.responses.count")}`}
+            {`${(form.nb_responses ?? 0).toString()} ${t("formulaire.responses.count")}`}
           </EllipsisWithTooltip>
         ),
       },

--- a/formulaire/frontend/src/hook/useFormItemsIcons.tsx
+++ b/formulaire/frontend/src/hook/useFormItemsIcons.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import { useTranslation } from "react-i18next";
 import PublicIcon from "@mui/icons-material/Public";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import ShareIcon from "@mui/icons-material/Share";
@@ -12,13 +11,12 @@ import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 import { ERROR_MAIN_COLOR, PRIMARY_MAIN_COLOR, SUCCESS_MAIN_COLOR, TEXT_SECONDARY_COLOR } from "~/core/style/colors";
 import { EllipsisWithTooltip } from "@cgi-learning-hub/ui";
 import { useFormatDateWithTime } from "./useFormatDateWithTime";
-import { FORMULAIRE } from "~/core/constants";
 import { getFormStatusText, isFormFilled } from "~/core/models/form/utils";
 import { IDistribution } from "~/core/models/distribution/types";
 import { getFirstDistributionDate } from "~/core/models/distribution/utils";
+import i18n from "~/i18n";
 
 export const useFormItemsIcons = () => {
-  const { t } = useTranslation(FORMULAIRE);
   const formatDateWithTime = useFormatDateWithTime();
 
   const getIcons = useCallback((form: IForm) => {
@@ -50,7 +48,7 @@ export const useFormItemsIcons = () => {
         .filter(({ condition }) => condition)
         // eslint-disable-next-line @typescript-eslint/naming-convention
         .map(({ textKey, IconComponent }) => ({
-          text: t(textKey),
+          text: i18n.t(textKey),
           icon: <IconComponent sx={{ color: (theme) => theme.palette.grey.darker }} />,
         }))
     );
@@ -76,7 +74,7 @@ export const useFormItemsIcons = () => {
         icon: <AssignmentTurnedInIcon sx={{ color: PRIMARY_MAIN_COLOR }} />,
         text: (
           <EllipsisWithTooltip typographyProps={{ color: TEXT_SECONDARY_COLOR }}>
-            {`${(form.nb_responses ?? 0).toString()} ${t("formulaire.responses.count")}`}
+            {`${(form.nb_responses ?? 0).toString()} ${i18n.t("formulaire.responses.count")}`}
           </EllipsisWithTooltip>
         ),
       },
@@ -112,7 +110,7 @@ export const useFormItemsIcons = () => {
               fontWeight: 700,
             }}
           >
-            {getFormStatusText(form, distributions, formatDateWithTime, t)}
+            {getFormStatusText(form, distributions, formatDateWithTime)}
           </EllipsisWithTooltip>
         ),
       },

--- a/formulaire/frontend/src/hook/useFormatDateWithTime.ts
+++ b/formulaire/frontend/src/hook/useFormatDateWithTime.ts
@@ -2,17 +2,17 @@ import { DD_MM_YYYY, HH_MM } from "~/core/constants";
 import dayjs from "dayjs";
 import "dayjs/locale/fr";
 import "dayjs/locale/en";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useFormatDateWithTime = () => {
   return (date: string | Date | undefined | null, i18nTextKey: string): string => {
     if (!date) return "";
 
-    const locale = i18n.t("formulaire.date.format.locale");
+    const locale = t("formulaire.date.format.locale");
     dayjs.locale(locale);
 
-    const text = i18n.t(i18nTextKey);
-    const atText = i18n.t("formulaire.at");
+    const text = t(i18nTextKey);
+    const atText = t("formulaire.at");
     const formattedDate = dayjs(date).format(DD_MM_YYYY);
     const formattedTime = dayjs(date).format(HH_MM);
 

--- a/formulaire/frontend/src/hook/useFormatDateWithTime.ts
+++ b/formulaire/frontend/src/hook/useFormatDateWithTime.ts
@@ -1,20 +1,18 @@
-import { useTranslation } from "react-i18next";
-import { DD_MM_YYYY, FORMULAIRE, HH_MM } from "~/core/constants";
+import { DD_MM_YYYY, HH_MM } from "~/core/constants";
 import dayjs from "dayjs";
 import "dayjs/locale/fr";
 import "dayjs/locale/en";
+import i18n from "~/i18n";
 
 export const useFormatDateWithTime = () => {
-  const { t } = useTranslation(FORMULAIRE);
-
   return (date: string | Date | undefined | null, i18nTextKey: string): string => {
     if (!date) return "";
 
-    const locale = t("formulaire.date.format.locale");
+    const locale = i18n.t("formulaire.date.format.locale");
     dayjs.locale(locale);
 
-    const text = t(i18nTextKey);
-    const atText = t("formulaire.at");
+    const text = i18n.t(i18nTextKey);
+    const atText = i18n.t("formulaire.at");
     const formattedDate = dayjs(date).format(DD_MM_YYYY);
     const formattedTime = dayjs(date).format(HH_MM);
 

--- a/formulaire/frontend/src/i18n.ts
+++ b/formulaire/frontend/src/i18n.ts
@@ -39,4 +39,8 @@ i18n
     debug: false,
   });
 
+export const t = (key: string, options?: Record<string, unknown>) => {
+  return i18n.t(key, options);
+};
+
 export default i18n;

--- a/formulaire/frontend/src/i18n.ts
+++ b/formulaire/frontend/src/i18n.ts
@@ -26,7 +26,7 @@ i18n
         return JSON.parse(data);
       },
     },
-    defaultNS: "common",
+    defaultNS: FORMULAIRE,
     // you can add name of the app directly in the ns array
     ns: ["common", FORMULAIRE],
     fallbackLng: "fr",
@@ -40,7 +40,7 @@ i18n
   });
 
 export const t = (key: string, options?: Record<string, unknown>) => {
-  return i18n.t(key, { ns: FORMULAIRE, ...options });
+  return i18n.t(key, options);
 };
 
 export default i18n;

--- a/formulaire/frontend/src/i18n.ts
+++ b/formulaire/frontend/src/i18n.ts
@@ -40,7 +40,7 @@ i18n
   });
 
 export const t = (key: string, options?: Record<string, unknown>) => {
-  return i18n.t(key, options);
+  return i18n.t(key, { ns: FORMULAIRE, ...options });
 };
 
 export default i18n;

--- a/formulaire/frontend/src/providers/HomeProvider/utils.ts
+++ b/formulaire/frontend/src/providers/HomeProvider/utils.ts
@@ -9,7 +9,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { hasWorkflow } from "~/core/utils";
 import { IUserWorkflowRights, IWorkflowRights, WorkflowRights } from "~/core/rights";
 import { IUserInfo } from "@edifice.io/client";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const useRootFolders = (): IFolder[] => {
   const rootFolders = useMemo<IFolder[]>(
@@ -17,7 +17,7 @@ export const useRootFolders = (): IFolder[] => {
       {
         id: RootFolderIds.FOLDER_MY_FORMS_ID,
         parent_id: null,
-        name: i18n.t("formulaire.forms.mine"),
+        name: t("formulaire.forms.mine"),
         icon: FolderIcon,
         user_id: "",
         nb_folder_children: 0,
@@ -28,7 +28,7 @@ export const useRootFolders = (): IFolder[] => {
       {
         id: RootFolderIds.FOLDER_SHARED_FORMS_ID,
         parent_id: null,
-        name: i18n.t("formulaire.forms.shared"),
+        name: t("formulaire.forms.shared"),
         icon: ShareIcon,
         user_id: "",
         nb_folder_children: 0,
@@ -39,7 +39,7 @@ export const useRootFolders = (): IFolder[] => {
       {
         id: RootFolderIds.FOLDER_ARCHIVED_ID,
         parent_id: null,
-        name: i18n.t("formulaire.forms.archived"),
+        name: t("formulaire.forms.archived"),
         icon: DeleteIcon,
         user_id: "",
         nb_folder_children: 0,

--- a/formulaire/frontend/src/providers/HomeProvider/utils.ts
+++ b/formulaire/frontend/src/providers/HomeProvider/utils.ts
@@ -12,7 +12,6 @@ import { IUserInfo } from "@edifice.io/client";
 import i18n from "~/i18n";
 
 export const useRootFolders = (): IFolder[] => {
-
   const rootFolders = useMemo<IFolder[]>(
     () => [
       {

--- a/formulaire/frontend/src/providers/HomeProvider/utils.ts
+++ b/formulaire/frontend/src/providers/HomeProvider/utils.ts
@@ -1,7 +1,5 @@
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import { IFolder } from "~/core/models/folder/types";
-import { FORMULAIRE } from "~/core/constants";
 import { HomeTabState, RootFolderIds } from "./enums";
 import { ViewMode } from "~/components/SwitchView/enums";
 import { IHomeTabViewPref, IUserTabRights } from "./types";
@@ -11,16 +9,16 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { hasWorkflow } from "~/core/utils";
 import { IUserWorkflowRights, IWorkflowRights, WorkflowRights } from "~/core/rights";
 import { IUserInfo } from "@edifice.io/client";
+import i18n from "~/i18n";
 
 export const useRootFolders = (): IFolder[] => {
-  const { t } = useTranslation(FORMULAIRE);
 
   const rootFolders = useMemo<IFolder[]>(
     () => [
       {
         id: RootFolderIds.FOLDER_MY_FORMS_ID,
         parent_id: null,
-        name: t("formulaire.forms.mine"),
+        name: i18n.t("formulaire.forms.mine"),
         icon: FolderIcon,
         user_id: "",
         nb_folder_children: 0,
@@ -31,7 +29,7 @@ export const useRootFolders = (): IFolder[] => {
       {
         id: RootFolderIds.FOLDER_SHARED_FORMS_ID,
         parent_id: null,
-        name: t("formulaire.forms.shared"),
+        name: i18n.t("formulaire.forms.shared"),
         icon: ShareIcon,
         user_id: "",
         nb_folder_children: 0,
@@ -42,7 +40,7 @@ export const useRootFolders = (): IFolder[] => {
       {
         id: RootFolderIds.FOLDER_ARCHIVED_ID,
         parent_id: null,
-        name: t("formulaire.forms.archived"),
+        name: i18n.t("formulaire.forms.archived"),
         icon: DeleteIcon,
         user_id: "",
         nb_folder_children: 0,

--- a/formulaire/frontend/src/services/api/services/archiveApi/importExportApi.ts
+++ b/formulaire/frontend/src/services/api/services/archiveApi/importExportApi.ts
@@ -8,7 +8,7 @@ import {
 } from "~/core/models/import/types";
 import { FORMULAIRE } from "~/core/constants";
 import { toast } from "react-toastify";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 
 export const importExportApi = emptySplitArchiveApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -25,7 +25,7 @@ export const importExportApi = emptySplitArchiveApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.import", err);
-          toast.error(i18n.t("formulaire.error.formService.import", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.import", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -42,7 +42,7 @@ export const importExportApi = emptySplitArchiveApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.import", err);
-          toast.error(i18n.t("formulaire.error.formService.import", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.import", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -60,7 +60,7 @@ export const importExportApi = emptySplitArchiveApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.import", err);
-          toast.error(i18n.t("formulaire.error.formService.import", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.import", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -76,7 +76,7 @@ export const importExportApi = emptySplitArchiveApi.injectEndpoints({
           window.location.href = `/archive/export/${exportId}`;
         } catch (err) {
           console.error("Error verifying export and downloading zip:", err);
-          toast.error(i18n.t("formulaire.error.formService.export", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.export", { ns: FORMULAIRE }));
         }
       },
     }),

--- a/formulaire/frontend/src/services/api/services/formulaireApi/distributionApi.ts
+++ b/formulaire/frontend/src/services/api/services/formulaireApi/distributionApi.ts
@@ -2,7 +2,7 @@ import { IDistribution, IDistributionDTO } from "~/core/models/distribution/type
 import { emptySplitFormulaireApi } from "./emptySplitFormulaireApi.ts";
 import { QueryMethod, TagName } from "~/core/enums";
 import { FORMULAIRE } from "~/core/constants.ts";
-import i18n from "~/i18n.ts";
+import { t } from "~/i18n.ts";
 import { toast } from "react-toastify";
 import { transformDistribution, transformDistributions } from "~/core/models/distribution/utils.ts";
 
@@ -20,7 +20,7 @@ export const distributionApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.distributionService.list", err);
-          toast.error(i18n.t("formulaire.error.distributionService.list", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.distributionService.list", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -47,7 +47,7 @@ export const distributionApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.distributionService.create", err);
-          toast.error(i18n.t("formulaire.error.distributionService.create", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.distributionService.create", { ns: FORMULAIRE }));
         }
       },
     }),

--- a/formulaire/frontend/src/services/api/services/formulaireApi/folderApi.ts
+++ b/formulaire/frontend/src/services/api/services/formulaireApi/folderApi.ts
@@ -2,7 +2,7 @@ import { IFolder, ICreateFolderPayload, IUpdateFolderPayload } from "~/core/mode
 import { emptySplitFormulaireApi } from "./emptySplitFormulaireApi.ts";
 import { QueryMethod, TagName } from "~/core/enums.ts";
 import { toast } from "react-toastify";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 import { FORMULAIRE } from "~/core/constants";
 
 export const folderApi = emptySplitFormulaireApi.injectEndpoints({
@@ -17,7 +17,7 @@ export const folderApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.folderService.list", err);
-          toast.error(i18n.t("formulaire.error.folderService.list", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.folderService.list", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -34,10 +34,10 @@ export const folderApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.folders.create", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.folders.create", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.folderService.create", err);
-          toast.error(i18n.t("formulaire.error.folderService.create", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.folderService.create", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -54,10 +54,10 @@ export const folderApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.folders.update", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.folders.update", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.folderService.update", err);
-          toast.error(i18n.t("formulaire.error.folderService.update", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.folderService.update", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -73,10 +73,10 @@ export const folderApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.folders.delete", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.folders.delete", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.folderService.delete", err);
-          toast.error(i18n.t("formulaire.error.folderService.delete", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.folderService.delete", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -92,10 +92,10 @@ export const folderApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.move", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.move", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.folderService.move", err);
-          toast.error(i18n.t("formulaire.error.folderService.move", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.folderService.move", { ns: FORMULAIRE }));
         }
       },
     }),

--- a/formulaire/frontend/src/services/api/services/formulaireApi/formApi.ts
+++ b/formulaire/frontend/src/services/api/services/formulaireApi/formApi.ts
@@ -8,7 +8,7 @@ import {
 import { emptySplitFormulaireApi } from "./emptySplitFormulaireApi.ts";
 import { QueryMethod, TagName } from "~/core/enums.ts";
 import { toast } from "react-toastify";
-import i18n from "~/i18n";
+import { t } from "~/i18n";
 import { FORMULAIRE, ID, LINK_HTML_ELEMENT, PDF_EXTENSION, TRASH_FOLDER_ID, ZIP_EXTENSION } from "~/core/constants";
 
 export const formApi = emptySplitFormulaireApi.injectEndpoints({
@@ -24,7 +24,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.list", err);
-          toast.error(i18n.t("formulaire.error.formService.list", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.list", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -39,7 +39,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.list", err);
-          toast.error(i18n.t("formulaire.error.formService.list", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.list", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -54,10 +54,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.form.create", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.form.create", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.create", err);
-          toast.error(i18n.t("formulaire.error.formService.create", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.create", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -72,10 +72,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted({ hasToastDisplay = true }, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          if (hasToastDisplay) toast.success(i18n.t("formulaire.success.form.save", { ns: FORMULAIRE }));
+          if (hasToastDisplay) toast.success(t("formulaire.success.form.save", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.update", err);
-          toast.error(i18n.t("formulaire.error.formService.update", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.update", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -89,10 +89,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.forms.delete", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.forms.delete", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.delete", err);
-          toast.error(i18n.t("formulaire.error.formService.delete", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.delete", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -107,10 +107,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.forms.duplicate", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.forms.duplicate", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.duplicate", err);
-          toast.error(i18n.t("formulaire.error.formService.duplicate", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.duplicate", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -126,10 +126,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
         try {
           await queryFulfilled;
           if (params.destinationFolderId !== TRASH_FOLDER_ID)
-            toast.success(i18n.t("formulaire.success.move", { ns: FORMULAIRE }));
+            toast.success(t("formulaire.success.move", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.move", err);
-          toast.error(i18n.t("formulaire.error.formService.move", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.move", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -144,10 +144,10 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.forms.restore", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.forms.restore", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.restore", err);
-          toast.error(i18n.t("formulaire.error.formService.restore", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.restore", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -170,7 +170,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
 
           const fileName =
             forms.length > 1
-              ? i18n.t("formulaire.export.pdf.questions.title") + ZIP_EXTENSION
+              ? t("formulaire.export.pdf.questions.title") + ZIP_EXTENSION
               : forms[0].title.replace(/\s+/g, "_") + PDF_EXTENSION;
 
           // Create a download link and trigger the download
@@ -184,7 +184,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
           URL.revokeObjectURL(downloadUrl);
         } catch (err) {
           console.error("formulaire.error.formService.export", err);
-          toast.error(i18n.t("formulaire.error.formService.export", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.export", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -199,7 +199,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.export", err);
-          toast.error(i18n.t("formulaire.error.formService.export", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.export", { ns: FORMULAIRE }));
         }
       },
       transformResponse: (response: { status: string; exportId: string; exportPath: string }) => {
@@ -217,7 +217,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
           await queryFulfilled;
         } catch (err) {
           console.error("formulaire.error.formService.rights", err);
-          toast.error(i18n.t("formulaire.error.formService.rights", { ns: FORMULAIRE }));
+          toast.error(t("formulaire.error.formService.rights", { ns: FORMULAIRE }));
         }
       },
     }),
@@ -230,7 +230,7 @@ export const formApi = emptySplitFormulaireApi.injectEndpoints({
       async onQueryStarted(_, { queryFulfilled }) {
         try {
           await queryFulfilled;
-          toast.success(i18n.t("formulaire.success.reminder.send", { ns: FORMULAIRE }));
+          toast.success(t("formulaire.success.reminder.send", { ns: FORMULAIRE }));
         } catch (err) {
           console.error("formulaire.error.formService.remind", err);
         }


### PR DESCRIPTION

## Describe your changes

* **Core change:**
  All calls to translations now use a direct `import i18n` + `i18n.t()` instead of the `useTranslation` hook and passing around `t`.

* **What was removed:**

  * The `useTranslation` hook
  * `t` parameters in utility functions and components

* **Where it applies:**

  * **Hooks:** `useColumns`, `useFolderSubtitle`, `useFormatDateWithTime`, `useFormItemsIcons`
  * **Utilities:** `getFormStatusText`, column‐building helpers
  * **Components:** Main and Sent Forms tables

* **Why it matters:**

  * Eliminates boilerplate
  * Keeps translation logic consistent
  * Simplifies the codebase

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)