### PR TITLE
fix(folder): #FOR-978 fix moving folder into itself

### DIFF
--- a/formulaire/frontend/src/containers/MoveFolderModal/index.tsx
+++ b/formulaire/frontend/src/containers/MoveFolderModal/index.tsx
@@ -29,7 +29,7 @@ export const MoveFolderModal: FC<IModalProps> = ({ isOpen, handleClose }) => {
   const [moveForms] = useMoveFormsMutation();
   const [moveFolders] = useMoveFoldersMutation();
 
-  const treeViewItems = buildFolderTree(folders);
+  const treeViewItems = buildFolderTree(folders, selectedFolders);
   const handleSelectedItemChange = useCallback(
     (event: SyntheticEvent, itemId: string | null) => {
       if (!itemId) {

--- a/formulaire/frontend/src/containers/MoveFolderModal/utils.ts
+++ b/formulaire/frontend/src/containers/MoveFolderModal/utils.ts
@@ -2,12 +2,15 @@ import { IFolder } from "~/core/models/folder/types";
 import { CustomTreeViewItem, ICON_TYPE } from "@cgi-learning-hub/ui";
 import { MYFORMS_FOLDER_ID } from "~/core/constants";
 
-export const buildFolderTree = (folders: IFolder[]): CustomTreeViewItem[] => {
+export const buildFolderTree = (folders: IFolder[], foldersToExcludeList: IFolder[] = []): CustomTreeViewItem[] => {
+  //Set.has is O(1) lookup, List.some would be O(n) lookup, avoid O(n*m) complexity
+  const excludedIds = new Set(foldersToExcludeList.map((f) => f.id));
+
   const rootFolders = folders.filter((folder) => folder.id === MYFORMS_FOLDER_ID);
 
   const buildNestedFolders = (parentId: number): CustomTreeViewItem[] => {
     return folders
-      .filter((folder) => folder.parent_id === parentId && folder.id !== parentId)
+      .filter((folder) => folder.parent_id === parentId && folder.id !== parentId && !excludedIds.has(folder.id))
       .map((folder) => {
         const childFolders = buildNestedFolders(folder.id);
 


### PR DESCRIPTION
## Describe your changes
This pull request enhances the functionality of the `MoveFolderModal` component by allowing the exclusion of specific folders from the folder tree view. The changes optimize the folder tree-building process and improve performance by using a `Set` for efficient lookups. 


* Modified the `treeViewItems` initialization in the `MoveFolderModal` component to pass the `selectedFolders` as the `foldersToExcludeList` parameter to the `buildFolderTree` function. (`formulaire/frontend/src/containers/MoveFolderModal/index.tsx`, [formulaire/frontend/src/containers/MoveFolderModal/index.tsxL32-R32](diffhunk://#diff-e3fb32bfefb9f8574b144162c2588dcda73c8c4d3e484a11a245d791d4a3f26aL32-R32))
## Checklist tests

## Issue ticket number and link
[FOR-978](https://jira.support-ent.fr/browse/FOR-978)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)