### PR TITLE
fix: do not try to log an error when NotifyCron was launched successfully

### DIFF
--- a/formulaire/backend/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
+++ b/formulaire/backend/src/main/java/fr/openent/formulaire/cron/NotifyCron.java
@@ -50,8 +50,7 @@ public class NotifyCron extends ControllerHelper implements Handler<Long> {
                 LogHelper.logError(this, "handle", errorMessage, notificationsEvt.left().getValue());
             }
             else {
-                String errorMessage = "Notify cron launch successful";
-                LogHelper.logError(this, "handle", errorMessage, notificationsEvt.left().getValue());
+                LogHelper.logInfo(this, "handle", "Notify cron launch successful");
             }
         });
     }


### PR DESCRIPTION
## Describe your changes

Cette PR permet de corriger une NPE qui survient après avoir lancé le job NotifyCron. On tentait de logguer une erreur  en accédant au _left_ du résultat qui n'était pas présent étant donné que le résultat était ok (et donc n'avait qu'un _right_).

## Checklist tests

Démarrage du cron et constater qu'on voit la log `Notify cron launch successful` au lieu de 
```
exception	
java.lang.NullPointerException
	at fr.openent.formulaire.cron.NotifyCron.lambda$handle$0(NotifyCron.java:54)
	at fr.openent.formulaire.cron.NotifyCron.lambda$launchNotifications$1(NotifyCron.java:64)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:310)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:208)
	at io.vertx.core.impl.future.CompositeFutureImpl.onSuccess(CompositeFutureImpl.java:114)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
	at io.vertx.core.Promise.tryComplete(Promise.java:121)
	at io.vertx.core.Promise.complete(Promise.java:77)
	at fr.openent.formulaire.cron.NotifyCron.lambda$notifyClosingForm$10(NotifyCron.java:121)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:310)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
	at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
	at io.vertx.core.Promise.complete(Promise.java:66)
	at fr.openent.form.helpers.FutureHelper.lambda$handlerEither$0(FutureHelper.java:24)
```

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)